### PR TITLE
Update to decorator and /api/v1/schema endpoint and other stuff from meeting with Sam

### DIFF
--- a/website/project/decorators.py
+++ b/website/project/decorators.py
@@ -64,7 +64,7 @@ def must_not_be_registration(func):
         _inject_nodes(kwargs)
         node = kwargs['node']
 
-        if node.is_registration:
+        if node.is_registration and not node.is_draft:
             raise HTTPError(http.BAD_REQUEST)
         return func(*args, **kwargs)
 

--- a/website/project/metadata/osf-standard-test.json
+++ b/website/project/metadata/osf-standard-test.json
@@ -31,8 +31,8 @@
 					"format":"textarea",
 					"title":"Other Comments"
 				}
-			},
+			}
 		}
 	],
-	"category": "draft",
+	"category": "draft"
 }

--- a/website/project/metadata/schemas.py
+++ b/website/project/metadata/schemas.py
@@ -1,18 +1,21 @@
 import os
 import json
 
+
 def ensure_schema_structure(schema):
-    if 'pages' not in schema['schema']:
-        schema['schema'] = {
-            'pages': [
-                {
-                    'id': 'page1',
-                    'title': '',
-                    'questions': schema['schema']['questions'],
-                }
-            ]
-        }
+    if 'type' not in schema:
+        schema['type'] = 'object'
+
+    if 'pages' not in schema:
+        schema['pages'] = [
+            {
+                'id': 'page1',
+                'type': 'object',
+            }
+        ]
+
     return schema
+
 
 here = os.path.split(os.path.abspath(__file__))[0]
 
@@ -20,9 +23,10 @@ def from_json(fname):
     return json.load(open(os.path.join(here, fname)))
 
 OSF_META_SCHEMAS = [
-    ensure_schema_structure(from_json('osf-open-ended-1.json')),
-    ensure_schema_structure(from_json('osf-standard-1.json')),
-    ensure_schema_structure(from_json('brandt-prereg-1.json')),
-    ensure_schema_structure(from_json('brandt-postcomp-1.json')),
-    #ensure_schema_structure(from_json('aea-prereg-1.json')),
+    # ensure_schema_structure(from_json('osf-open-ended-1.json')),
+    # ensure_schema_structure(from_json('osf-standard-1.json')),
+    ensure_schema_structure(from_json('osf-standard-test.json')),
+    # ensure_schema_structure(from_json('brandt-prereg-1.json')),
+    ensure_schema_structure(from_json('brandt-prereg-test.json')),
+    # ensure_schema_structure(from_json('brandt-postcomp-1.json')),
 ]

--- a/website/project/model.py
+++ b/website/project/model.py
@@ -114,7 +114,7 @@ def ensure_schemas(clear=True):
                 Q('schema_version', 'eq', schema['schema_version'])
             )
         except:
-            schema['name'] = schema['name'].replace(' ', '_')
+            schema['id'] = schema['id'].replace(' ', '_')
             schema_obj = MetaSchema(**schema)
             schema_obj.save()
 

--- a/website/project/views/register.py
+++ b/website/project/views/register.py
@@ -48,16 +48,19 @@ def node_register_page(auth, node, **kwargs):
 
 
 def get_metaschema_by_name():
-    names = [schema['id'] for schema in OSF_META_SCHEMAS]
+    """ By default returns a list of all available OSF metaschemas
+    Accepts a query string in the form of ?id=name_of_schema that will return just that schema if the ids match exactly
+    """
+    schema_ids = [schema['id'] for schema in OSF_META_SCHEMAS]
+
     if request.query_string:
-        query_name = request.query_string.split('=')[1].replace('%20', '_')
-        if query_name:
-            for name in names:
-                if name.lower() == query_name.lower():
-                    for schema in OSF_META_SCHEMAS:
-                        if schema['id'] == name:
-                            return schema
-            return {'message': 'Schema not found, please be sure the name matches exactly'}
+        query_id = request.query_string.split('=')[1].replace('%20', '_')
+        for schema_id in schema_ids:
+            if schema_id.lower() == query_id.lower():
+                for schema in OSF_META_SCHEMAS:
+                    return schema if schema['id'] == schema_id else {
+                        'message': 'Schema not found, please be sure the ids match exactly'}
+
     return OSF_META_SCHEMAS
 
 

--- a/website/project/views/register.py
+++ b/website/project/views/register.py
@@ -28,7 +28,6 @@ from website.identifiers.client import EzidClient
 
 from .node import _view_project
 from .. import clean_template_name
-from ..metadata.schemas import OSF_META_SCHEMAS
 
 @must_be_valid_project
 @must_have_permission(ADMIN)
@@ -48,7 +47,14 @@ def node_register_page(auth, node, **kwargs):
     return ret
 
 def get_metaschema_by_name(**kwargs):
-    pass
+    names = [schema['name'] for schema in OSF_META_SCHEMAS]
+    query_name = request.query_string.split('=')[1].replace('%20', '_')
+    for name in names:
+        if name.lower() == query_name.lower():
+            for schema in OSF_META_SCHEMAS:
+                if schema['name'] == name:
+                    return schema
+    return {'message': 'Schema not found, please be sure the name matches exactly'}
 
 @must_be_valid_project
 @must_have_permission(ADMIN)

--- a/website/project/views/register.py
+++ b/website/project/views/register.py
@@ -46,15 +46,18 @@ def node_register_page(auth, node, **kwargs):
     ret.update(_view_project(node, auth, primary=True))
     return ret
 
-def get_metaschema_by_name(**kwargs):
-    names = [schema['name'] for schema in OSF_META_SCHEMAS]
-    query_name = request.query_string.split('=')[1].replace('%20', '_')
-    for name in names:
-        if name.lower() == query_name.lower():
-            for schema in OSF_META_SCHEMAS:
-                if schema['name'] == name:
-                    return schema
-    return {'message': 'Schema not found, please be sure the name matches exactly'}
+def get_metaschema_by_name():
+    names = [schema['id'] for schema in OSF_META_SCHEMAS]
+    try:
+        query_name = request.query_string.split('=')[1].replace('%20', '_')
+        for name in names:
+            if name.lower() == query_name.lower():
+                for schema in OSF_META_SCHEMAS:
+                    if schema['id'] == name:
+                        return schema
+        return {'message': 'Schema not found, please be sure the name matches exactly'}
+    except IndexError:
+        return {'message': 'Please enter a querystring in the format of /schema/?id=NAME_OF_SCHEMA'}
 
 @must_be_valid_project
 @must_have_permission(ADMIN)

--- a/website/project/views/register.py
+++ b/website/project/views/register.py
@@ -28,7 +28,7 @@ from website.identifiers.client import EzidClient
 
 from .node import _view_project
 from .. import clean_template_name
-
+from ..metadata.schemas import OSF_META_SCHEMAS
 
 @must_be_valid_project
 @must_have_permission(ADMIN)
@@ -46,6 +46,9 @@ def node_register_page(auth, node, **kwargs):
     }
     ret.update(_view_project(node, auth, primary=True))
     return ret
+
+def get_metaschema_by_name(**kwargs):
+    pass
 
 @must_be_valid_project
 @must_have_permission(ADMIN)

--- a/website/project/views/register.py
+++ b/website/project/views/register.py
@@ -37,8 +37,8 @@ def node_register_page(auth, node, **kwargs):
     ret = {
         'options': [
             {
-                'template_name': metaschema['name'],
-                'template_name_clean': clean_template_name(metaschema['name'])
+                'template_name': metaschema['id'],
+                'template_name_clean': clean_template_name(metaschema['id'])
             }
             for metaschema in OSF_META_SCHEMAS
         ]

--- a/website/project/views/register.py
+++ b/website/project/views/register.py
@@ -29,11 +29,11 @@ from website.identifiers.client import EzidClient
 from .node import _view_project
 from .. import clean_template_name
 
+
 @must_be_valid_project
 @must_have_permission(ADMIN)
 @must_not_be_registration
 def node_register_page(auth, node, **kwargs):
-
     ret = {
         'options': [
             {
@@ -41,23 +41,25 @@ def node_register_page(auth, node, **kwargs):
                 'template_name_clean': clean_template_name(metaschema['id'])
             }
             for metaschema in OSF_META_SCHEMAS
-        ]
+            ]
     }
     ret.update(_view_project(node, auth, primary=True))
     return ret
 
+
 def get_metaschema_by_name():
     names = [schema['id'] for schema in OSF_META_SCHEMAS]
-    try:
+    if request.query_string:
         query_name = request.query_string.split('=')[1].replace('%20', '_')
-        for name in names:
-            if name.lower() == query_name.lower():
-                for schema in OSF_META_SCHEMAS:
-                    if schema['id'] == name:
-                        return schema
-        return {'message': 'Schema not found, please be sure the name matches exactly'}
-    except IndexError:
-        return {'message': 'Please enter a querystring in the format of /schema/?id=NAME_OF_SCHEMA'}
+        if query_name:
+            for name in names:
+                if name.lower() == query_name.lower():
+                    for schema in OSF_META_SCHEMAS:
+                        if schema['id'] == name:
+                            return schema
+            return {'message': 'Schema not found, please be sure the name matches exactly'}
+    return OSF_META_SCHEMAS
+
 
 @must_be_valid_project
 @must_have_permission(ADMIN)
@@ -80,7 +82,6 @@ def node_register_edit_page(auth, node, **kwargs):
 @must_be_valid_project
 @must_be_contributor_or_public
 def node_register_template_page(auth, node, **kwargs):
-
     template_name = kwargs['template'].replace(' ', '_')
     # Error to raise if template can't be found
     not_found_error = HTTPError(
@@ -139,11 +140,11 @@ def node_register_template_page(auth, node, **kwargs):
     ret.update(_view_project(node, auth, primary=True))
     return ret
 
+
 # TODO
 @must_be_valid_project
 @must_be_contributor_or_public
 def node_draft_template_page(auth, node, **kwargs):
-
     template_name = kwargs['template'].replace(' ', '_')
     # Error to raise if template can't be found
     not_found_error = HTTPError(
@@ -220,6 +221,7 @@ def project_before_register(auth, node, **kwargs):
 
     return {'prompts': prompts}
 
+
 @must_be_valid_project  # returns project TODO
 @must_have_permission(ADMIN)
 @must_not_be_registration
@@ -265,15 +267,15 @@ def node_register_template_page_post(auth, node, **kwargs):
     )
 
     return {
-        'status': 'success',
-        'result': register.url,
-    }, http.CREATED
+               'status': 'success',
+               'result': register.url,
+           }, http.CREATED
+
 
 @must_be_valid_project
 @must_have_permission(ADMIN)
 @must_not_be_registration
 def node_draft_template_page_post(auth, node, **kwargs):
-
     if settings.DISK_SAVING_MODE:
         raise HTTPError(
             http.METHOD_NOT_ALLOWED,
@@ -286,9 +288,10 @@ def node_draft_template_page_post(auth, node, **kwargs):
     draft = node.register_node(auth)
 
     return {
-        'status': 'success',
-        'result': draft.url,
-    }, http.CREATED
+               'status': 'success',
+               'result': draft.url,
+           }, http.CREATED
+
 
 def _build_ezid_metadata(node):
     """Build metadata for submission to EZID using the DataCite profile. See

--- a/website/routes.py
+++ b/website/routes.py
@@ -270,7 +270,7 @@ def make_url_map(app):
     process_rules(app, [
         Rule(
             [
-                '/schema/',
+                '/schemas/',
             ],
             'get', project_views.register.get_metaschema_by_name, json_renderer),
     ], prefix='/api/v1')

--- a/website/routes.py
+++ b/website/routes.py
@@ -270,6 +270,14 @@ def make_url_map(app):
     process_rules(app, [
         Rule(
             [
+                '/schema/',
+            ],
+            'get', project_views.register.get_metaschema_by_name, json_renderer),
+    ], prefix='/api/v1')
+
+    process_rules(app, [
+        Rule(
+            [
                 '/oauth/accounts/<external_account_id>/',
             ],
             'delete',

--- a/website/static/js/pages/register-page.js
+++ b/website/static/js/pages/register-page.js
@@ -550,37 +550,36 @@ var ctx = window.contextVars;
     document.getElementById('save').onclick = function () {
         var schema;
         var value;
-        for (schema in init_schemas[which_schema]) {
-            if (init_schemas[which_schema][schema].title === editor.options.schema.title) {
-                for (value in editor.getValue()) {
-                   schema_data[schema][value] = editor.getValue()[value];
-                }
-            }
-        } 
+       for (schema in init_schemas[which_schema]) {
+           if (init_schemas[schema][schema].title === editor.options.schema.title) {
+               for (value in editor.getValue()) {
+                  schema_data[schema][value] = editor.getValue()[value];
+               }
+           }
+       }
     };
 
 })();
 
 $(document).ready(function() {
-
-    // $.ajax({
-    //     url: ctx.node.urls.api + 'beforedraft/',
-    //     contentType: 'application/json',
-    //     success: function(response) {
-    //         if (response.prompts && response.prompts.length) {
-    //             bootbox.confirm(
-    //                 $osf.joinPrompts(response.prompts, 'Are you sure you want to create a draft of this project?'),
-    //                 function(result) {
-    //                     if (result) {
-    //                         draftNode(data);
-    //                     }
-    //                 }
-    //             );
-    //         } else {
-    //             draftNode(data);
-    //         }
-    //     }
-    // });
+     //$.ajax({
+     //    url: ctx.node.urls.api + 'beforedraft/',
+     //    contentType: 'application/json',
+     //    success: function(response) {
+     //        if (response.prompts && response.prompts.length) {
+     //            bootbox.confirm(
+     //                $osf.joinPrompts(response.prompts, 'Are you sure you want to create a draft of this project?'),
+     //                function(result) {
+     //                    if (result) {
+     //                        draftNode(data);
+     //                    }
+     //                }
+     //            );
+     //        } else {
+     //            draftNode(data);
+     //        }
+     //    }
+     //});
 
 
     // Don't submit form on enter; must use $.delegate rather than $.on


### PR DESCRIPTION
# Changed:
- Modified must_not_be_registration decorator to take into account drafts
- Add `api/v1/schema` endpoint
  - Must be accessed with query strings such as `/api/v1/schema/?id=osf-standard_pre-data_collection_registration`
  - The query string check is not case sensitive but must match the id exactly
  - Responses from this endpoint look something like: ![screen shot 2015-06-22 at 4 08 26 pm](https://cloud.githubusercontent.com/assets/8905795/8291671/04fcfa4c-18f9-11e5-99ac-4db194d851c8.png)
  - Only returns json schemas with your `*-test.json` format relying heavily on the `id` key. This will cause breakage and side effects documented below
- Slight changes to your json schemas to comply with the JSON specification not allowing trailing commas
- Modify `websit/project/metadata/schemas.py` to validate against our new schema format. The breakage that goes along with this is the same as from the query string change
# Side effects
- Will either require a DB migration for all json schemas with `'name'` keys and change them to `'id'` keys. or changing our schemas to use `name` instead. Probably equal effort on either side.
