### PR TITLE
Couple of small Admin things

### DIFF
--- a/website/project/metadata/prereg-prize-test.json
+++ b/website/project/metadata/prereg-prize-test.json
@@ -16,7 +16,7 @@
                 "type": "object",
                 "properties": {
                     "q1": {
-                        "type": "commentableString",
+                        "type": "osf-string",
                         "format": "text",
                         "title": "Title",
                         "description": "What is the working title of your study? It is helpful if this is the same title that you submit for publication of your final manuscript, but it is not a requirement.",
@@ -31,7 +31,7 @@
                 "type": "object",
                 "properties": {
                     "q2": {
-                        "type": "commentableString",
+                        "type": "osf-string",
                         "format": "text",
                         "title": "Authorship",
                         "description": "The first author of the pre-registered study is the recipient of the award money and must also be the first author of the published manuscript. Additional authors may be added or removed at any time.",
@@ -46,7 +46,7 @@
                 "type": "object",
                 "properties": {
                     "q3": {
-                        "type": "commentableString",
+                        "type": "osf-string",
                         "format": "textarea",
                         "title": "Conflict of Interest",
                         "description": "Could the results of this project benefit the financial interests of any of its authors, or be reasonably perceived to do so?",
@@ -61,7 +61,7 @@
                 "type": "object",
                 "properties": {
                     "q4": {
-                        "type": "commentableString",
+                        "type": "osf-string",
                         "format": "textarea",
                         "title": "Research questions and hypotheses",
                         "description": "What are your research questions and hypotheses?",
@@ -82,7 +82,7 @@
                 "type": "object",
                 "properties": {
                     "q5": {
-                        "type": "commentableString",
+                        "type": "osf-string",
                         "format": "textarea",
                         "title": "Data collection procedures",
                         "description": "Please describe your data collection procedures. This may include the population from which you obtain subjects, recruitment efforts, how subjects will be selected for eligibility from the initial pool (e.g. inclusion and exclusion rules), and your study timeline.",
@@ -97,7 +97,7 @@
                 "type": "object",
                 "properties": {
                     "q6": {
-                        "type": "commentableString",
+                        "type": "osf-string",
                         "format": "text",
                         "title": "Sample Size",
                         "description": "How many units will be analyzed in the study? This could be the number of people, birds, classrooms, plots, interactions, or countries included. If the units are not individuals, then describe the size requirements for each unit.",
@@ -112,7 +112,7 @@
                 "type": "object",
                 "properties": {
                     "q7": {
-                        "type": "commentableString",
+                        "type": "osf-string",
                         "format": "textarea",
                         "title": "Please describe your rationale for picking this sample size.",
                         "description": "This could include a power analysis or an arbitrary constraint such as resource availability. Include a stopping rule that is not dependent on investigating the data as it is collected.",
@@ -131,7 +131,7 @@
                         "title": "Please check and certify one of the following statements.",
                         "uniqueItems": true,
                         "items": {
-                            "type": "commentableString",
+                            "type": "osf-string",
                             "enum": ["I certify that none of the data that will be used in this upcoming study have yet been collected. Please enter your name and the phrase _I certifyî in the following box. Why is this necessary?", "I will be using pre-existing data in this study. I certify that I have no knowledge about any of its basic descriptive statistics, nor am I aware of any differences or relationships within the data that I will use. Please enter your name and the phrase _I certifyî in the following boxes."]
                         }
                     }
@@ -154,7 +154,7 @@
                         "title": "What type of study is this?",
                         "uniqueItems": true,
                         "items": {
-                            "type": "commentableString",
+                            "type": "osf-string",
                             "enum": ["Experiment (A researcher randomly assigns treatments to study subjects, this includes field or lab experiments. This is also known as an intervention experiment or a randomized controlled trial.", "Observational Study (Data is collected from study subjects that are not randomly assigned to a treatment. This includes surveys, _natural experiments,î and regression discontinuity designs.)", "Meta-Analysis (a systematic review of published studies)", "Other (please explain)"]
                         }
                     }
@@ -171,7 +171,7 @@
                         "title": "Are any aspects of your study _blindedî?",
                         "uniqueItems": true,
                         "items": {
-                            "type": "commentableString",
+                            "type": "osf-string",
                             "enum": ["Not applicable: This study will not assign treatments to subjects (e.g. observational studies or meta-analyses).", "Yes, single blind: Human subjects of the study will not know if they are assigned to a treatment or control group. Experimenters will have that knowledge.", "Yes, double blind: Neither the human subjects, nor the experimenters taking measurements from a subject will have knowledge of the treatment.", "No: both human subjects and researchers are aware of the treatment groups.", " Yes: I am using non-human study subjects, and researchers collecting data are ignorant of each subjects treatment group.", "No: researchers are aware of the treatment groups."]
                         }
                     }
@@ -184,7 +184,7 @@
                 "type": "object",
                 "properties": {
                     "q11": {
-                        "type": "commentableString",
+                        "type": "osf-string",
                         "format": "text",
                         "title": "Describe your study design.",
                         "description": "Examples include two-group, factorial, randomized block, and repeated measures. Is it a between or within-subject design? Describe any counterbalancing required. Typical study designs for observation studies include cohort, cross sectional, and case-control studies. You will be asked to define your variables in detail in the upcoming sections.",
@@ -199,7 +199,7 @@
                 "type": "object",
                 "properties": {
                     "q12": {
-                        "type": "commentableString",
+                        "type": "osf-string",
                         "format": "textarea",
                         "title": "Define your predictor variable(s).",
                         "description": "If applicable, describe the levels for each predictor. If your predictor variables are constructed from multiple measurements, you will be asked later on to describe how they are created. ",
@@ -214,7 +214,7 @@
                 "type": "object",
                 "properties": {
                     "q13": {
-                        "type": "commentableString",
+                        "type": "osf-string",
                         "format": "textarea",
                         "title": "Define your outcome variable(s).",
                         "description": "If your outcome measurements are constructed from multiple measurements, you will be asked later on to describe how they are created.",
@@ -229,7 +229,7 @@
                 "type": "object",
                 "properties": {
                     "q14": {
-                        "type": "commentableString",
+                        "type": "osf-string",
                         "format": "textarea",
                         "title": "Covariates.",
                         "description": "If applicable, and not mentioned above, what covariates, controls, or other independent variables will you measure?",
@@ -244,7 +244,7 @@
                 "type": "object",
                 "properties": {
                     "q15": {
-                        "type": "commentableString",
+                        "type": "osf-string",
                         "format": "textarea",
                         "title": "If you are doing a randomized study, how will you randomize, and at what level?",
                         "description": "There are many different randomization techniques. The appropriateness of each will depend on the specifics of your study.",
@@ -265,7 +265,7 @@
                 "type": "object",
                 "properties": {
                     "q16": {
-                        "type": "commentableString",
+                        "type": "osf-string",
                         "format": "textarea",
                         "title": "Constructing predictor variables",
                         "description": "Often, a main predictor will not be a single measurement, but an index made from several other measurements. What measures will you use and how will they be combined to make your outcome variable(s).",
@@ -280,7 +280,7 @@
                 "type": "object",
                 "properties": {
                     "q17": {
-                        "type": "commentableString",
+                        "type": "osf-string",
                         "format": "textarea",
                         "title": "Constructing outcome variables",
                         "description": "Just as with the previous question, how will specific measures be combined to create your predictor variable(s)?",
@@ -295,7 +295,7 @@
                 "type": "object",
                 "properties": {
                     "q18": {
-                        "type": "commentableString",
+                        "type": "osf-string",
                         "format": "textarea",
                         "title": "How will you determine what data or samples (if any) to exclude from your analyses?",
                         "description": "Are there specific criteria that must be met in order to include? How will outliers be handled? You may want to attach a decision tree with an _if, then” structure to easily formalize the way in which these decisions will be made.",
@@ -310,7 +310,7 @@
                 "type": "object",
                 "properties": {
                     "q19": {
-                        "type": "commentableString",
+                        "type": "osf-string",
                         "format": "textarea",
                         "title": "How will you deal with incomplete or missing data?",
                         "description": "Almost every study will have missing data points. How you cope with these missing points is important because it can affect the result of your analysis.",
@@ -325,7 +325,7 @@
                 "type": "object",
                 "properties": {
                     "q20": {
-                        "type": "commentableString",
+                        "type": "osf-string",
                         "format": "textarea",
                         "title": "What statistical model(s) will you use to test your hypothesis(ses).",
                         "description": "Please include the type of model (e.g. ANOVA, regression, SEM, etc) as well as the specification of the model (e.g. what variables will be included). If you are using a method other than null hypothesis significance testing, such as a Bayesian method, provide the criteria you will use for making an evidence-based conclusion. Include likely alternative analyses or data transformations. ",
@@ -340,7 +340,7 @@
                 "type": "object",
                 "properties": {
                     "q21": {
-                        "type": "commentableString",
+                        "type": "osf-string",
                         "format": "textarea",
                         "title": "If you are comparing multiple conditions or testing multiple hypotheses, how will you account for this?",
                         "description": "When you conduct multiple comparisons, the odds of finding one statistically significant result because of random chance, instead of true relationships, increases. Click here for some more information.",
@@ -362,7 +362,7 @@
                 "properties": {
                     "q22": {
                         "title": "(Optional) Upload an analysis script with clear comments.",
-                        "type": "commentableString",
+                        "type": "osf-string",
                         "description": "This optional step is helpful in order to create a process that is completely transparent and increase the likelihood that your analysis can be replicated. We recommend that you run the code on a simulated dataset in order to check that it will run without errors.",
                         "format": "url",
                         "options": {

--- a/website/project/metadata/prereg-prize-test.json
+++ b/website/project/metadata/prereg-prize-test.json
@@ -3,377 +3,238 @@
     "version": 1,
     "type": "object",
     "description": "Pre-Registration Prize (pre-data collection): You will be asked a series of questions to ensure that your sampling, design, and analysis plans are solidified prior to beginning your study. Publications that pre-register with this template may be eligible for a $1,000 prize. <a href=\"https://osf.io/x5w7h/\">See project page for complete information</a>.",
-    "fulfills": ["prereg"],
-    "pages": [{
-        "id": "page1",
-        "title": "Basic Information",
-        "type": "object",
-        "questions": [
-            {
-                "id": "1",
-                "nav": "Title",
-                "title": "Basic Information",
-                "type": "object",
-                "properties": {
-                    "q1": {
-                        "type": "osf-string",
-                        "format": "text",
-                        "title": "Title",
-                        "description": "What is the working title of your study? It is helpful if this is the same title that you submit for publication of your final manuscript, but it is not a requirement.",
-                        "help": "Effect of sugar on brownie tastiness."
-                    }
-                }
-            },
-            {
-                "id": "2",
-                "nav": "Author",
-                "title": "Basic Information",
-                "type": "object",
-                "properties": {
-                    "q2": {
-                        "type": "osf-string",
-                        "format": "text",
-                        "title": "Authorship",
-                        "description": "The first author of the pre-registered study is the recipient of the award money and must also be the first author of the published manuscript. Additional authors may be added or removed at any time.",
-                        "help": "Jimmy Stewart, Ava Gardner, Bob Hope, Greta Garbo"
-                    }
-                }
-            },
-            {   
-                "id": "3",
-                "nav": "COI",
-                "title": "Basic Information",
-                "type": "object",
-                "properties": {
-                    "q3": {
-                        "type": "osf-string",
-                        "format": "textarea",
-                        "title": "Conflict of Interest",
-                        "description": "Could the results of this project benefit the financial interests of any of its authors, or be reasonably perceived to do so?",
-                        "help": "The authors of this study own a majority share of Tastee Sugar Company."
-                    }
-                }
-            },
-            {
-                "id": "4",
-                "nav": "Hypothesis",
-                "title": "Basic Information",
-                "type": "object",
-                "properties": {
-                    "q4": {
-                        "type": "osf-string",
-                        "format": "textarea",
-                        "title": "Research questions and hypotheses",
-                        "description": "What are your research questions and hypotheses?",
-                        "help": "There is strong evidence to suggest that sugar affects taste preferences, but the effect has never been demonstrated in brownies. Therefore, we will measure taste preference for four different levels of sugar concentration in a standard brownie recipe. If taste effects preferences, then mean preference indices will be higher with higher concentrations of sugar."
-                    }
+    "fulfills": [
+        "prereg"
+    ],
+    "pages": [
+        {
+            "id": "page1",
+            "title": "Basic Information",
+            "type": "object",
+            "questions": {
+                "q1": {
+                    "nav": "Title",
+                    "type": "string",
+                    "format": "text",
+                    "title": "Title",
+                    "description": "What is the working title of your study? It is helpful if this is the same title that you submit for publication of your final manuscript, but it is not a requirement.",
+                    "help": "Effect of sugar on brownie tastiness."
+                },
+                "q2": {
+                    "nav": "Authors",
+                    "type": "string",
+                    "format": "text",
+                    "title": "Authorship",
+                    "description": "The first author of the pre-registered study is the recipient of the award money and must also be the first author of the published manuscript. Additional authors may be added or removed at any time.",
+                    "help": "Jimmy Stewart, Ava Gardner, Bob Hope, Greta Garbo"
+                },
+                "q3": {
+                    "nav": "COI",
+                    "type": "string",
+                    "format": "textarea",
+                    "title": "Conflict of Interest",
+                    "description": "Could the results of this project benefit the financial interests of any of its authors, or be reasonably perceived to do so?",
+                    "help": "The authors of this study own a majority share of Tastee Sugar Company."
+                },
+                "q4": {
+                    "nav": "Research",
+                    "type": "string",
+                    "format": "textarea",
+                    "title": "Research questions and hypotheses",
+                    "description": "What are your research questions and hypotheses?",
+                    "help": "There is strong evidence to suggest that sugar affects taste preferences, but the effect has never been demonstrated in brownies. Therefore, we will measure taste preference for four different levels of sugar concentration in a standard brownie recipe. If taste effects preferences, then mean preference indices will be higher with higher concentrations of sugar."
                 }
             }
-        ]
-    }, {
-        "id": "page2",
-        "title": "Sampling Plan",
-        "type": "object",
-        "questions": [
-            {
-                "id": "5",
-                "nav": "Procedures",
-                "title": "Sampling Plan",
-                "type": "object",
-                "properties": {
-                    "q5": {
-                        "type": "osf-string",
-                        "format": "textarea",
-                        "title": "Data collection procedures",
-                        "description": "Please describe your data collection procedures. This may include the population from which you obtain subjects, recruitment efforts, how subjects will be selected for eligibility from the initial pool (e.g. inclusion and exclusion rules), and your study timeline.",
-                        "help": "Participants will be recruited through advertisements at local pastry shops. Participants will be paid $10 for agreeing to  participating (raised to $30 if our sample size is not reached within 15 days of beginning recruitment). Participants must be at least 18 years old and be able to eat the ingredients of the pastries."
-                    }
-                }
-            },
-            {
-                "id": "6",
-                "nav": "Sample Size",
-                "title": "Sampling Plan",
-                "type": "object",
-                "properties": {
-                    "q6": {
-                        "type": "osf-string",
-                        "format": "text",
-                        "title": "Sample Size",
-                        "description": "How many units will be analyzed in the study? This could be the number of people, birds, classrooms, plots, interactions, or countries included. If the units are not individuals, then describe the size requirements for each unit.",
-                        "help": "Our target sample size is 280 participants. We will attempt to recruit up to 320, assuming that not all will complete the total task."
-                    }
-                }
-            },
-            {
-                "id": "7",
-                "nav": "Rationale",
-                "title": "Sampling Plan",
-                "type": "object",
-                "properties": {
-                    "q7": {
-                        "type": "osf-string",
-                        "format": "textarea",
-                        "title": "Please describe your rationale for picking this sample size.",
-                        "description": "This could include a power analysis or an arbitrary constraint such as resource availability. Include a stopping rule that is not dependent on investigating the data as it is collected.",
-                        "help": "We used the software program G*Power to conduct a power analysis. Our goal was to obtain .95 power to detect a medium effect size of .25 at the standard .05 alpha error probability. We will stop recruiting participants at 320 (to account for incomplete data) or after 30 days, whichever comes first."
-                    }
-                }
-            },
-            {
-                "id": "8",
-                "nav": "Verify",
-                "title": "Sampling Plan",
-                "type": "object",
-                "properties": {
-                    "q8": {
-                        "type": "array",
-                        "title": "Please check and certify one of the following statements.",
-                        "uniqueItems": true,
-                        "items": {
-                            "type": "osf-string",
-                            "enum": ["I certify that none of the data that will be used in this upcoming study have yet been collected. Please enter your name and the phrase _I certifyî in the following box. Why is this necessary?", "I will be using pre-existing data in this study. I certify that I have no knowledge about any of its basic descriptive statistics, nor am I aware of any differences or relationships within the data that I will use. Please enter your name and the phrase _I certifyî in the following boxes."]
-                        }
-                    }
-                }
-            }
-        ]
-    }, {
-        "id": "page3",
-        "title": "Design Plan",
-        "type": "object",
-        "questions": [
-            {
-                "id": "9",
-                "nav": "Type",
-                "title": "Design Plan",
-                "type": "object",
-                "properties": {
-                    "q9": {
-                        "type": "array",
-                        "title": "What type of study is this?",
-                        "uniqueItems": true,
-                        "items": {
-                            "type": "osf-string",
-                            "enum": ["Experiment (A researcher randomly assigns treatments to study subjects, this includes field or lab experiments. This is also known as an intervention experiment or a randomized controlled trial.", "Observational Study (Data is collected from study subjects that are not randomly assigned to a treatment. This includes surveys, _natural experiments,î and regression discontinuity designs.)", "Meta-Analysis (a systematic review of published studies)", "Other (please explain)"]
-                        }
-                    }
-                }
-            },
-            {
-                "id": "10",
-                "nav": "Blind",
-                "title": "Design Plan",
-                "type": "object",
-                "properties": {
-                    "q10": {
-                        "type": "array",
-                        "title": "Are any aspects of your study _blindedî?",
-                        "uniqueItems": true,
-                        "items": {
-                            "type": "osf-string",
-                            "enum": ["Not applicable: This study will not assign treatments to subjects (e.g. observational studies or meta-analyses).", "Yes, single blind: Human subjects of the study will not know if they are assigned to a treatment or control group. Experimenters will have that knowledge.", "Yes, double blind: Neither the human subjects, nor the experimenters taking measurements from a subject will have knowledge of the treatment.", "No: both human subjects and researchers are aware of the treatment groups.", " Yes: I am using non-human study subjects, and researchers collecting data are ignorant of each subjects treatment group.", "No: researchers are aware of the treatment groups."]
-                        }
-                    }
-                }
-            },
-            {
-                "id": "11",
-                "nav": "Description",
-                "title": "Design Plan",
-                "type": "object",
-                "properties": {
-                    "q11": {
-                        "type": "osf-string",
-                        "format": "text",
-                        "title": "Describe your study design.",
-                        "description": "Examples include two-group, factorial, randomized block, and repeated measures. Is it a between or within-subject design? Describe any counterbalancing required. Typical study designs for observation studies include cohort, cross sectional, and case-control studies. You will be asked to define your variables in detail in the upcoming sections.",
-                        "help": "In our between-subject design, each of the 280 expected participants will taste one of the four levels of brownies (1X4)"
-                    }
-                }
-            },
-            {
-                "id": "12",
-                "nav": "Predictor",
-                "title": "Design Plan",
-                "type": "object",
-                "properties": {
-                    "q12": {
-                        "type": "osf-string",
-                        "format": "textarea",
-                        "title": "Define your predictor variable(s).",
-                        "description": "If applicable, describe the levels for each predictor. If your predictor variables are constructed from multiple measurements, you will be asked later on to describe how they are created. ",
-                        "help": "Our predictor is the amount of sugar added per brownie. The dry ingredients for each brownie will contain 15%, 20%, 25%, or 40% cane sugar by mass."
-                    }
-                }
-            },
-            {
-                "id": "13",
-                "nav": "Outcome",
-                "title": "Design Plan",
-                "type": "object",
-                "properties": {
-                    "q13": {
-                        "type": "osf-string",
-                        "format": "textarea",
-                        "title": "Define your outcome variable(s).",
-                        "description": "If your outcome measurements are constructed from multiple measurements, you will be asked later on to describe how they are created.",
-                        "help": "The single outcome variable will be the perceived tastiness of the single brownie each participant will eat."
-                    }
-                }
-            },
-            {
-                "id": "14",
-                "nav": "Covariates",
-                "title": "Design Plan",
-                "type": "object",
-                "properties": {
-                    "q14": {
-                        "type": "osf-string",
-                        "format": "textarea",
-                        "title": "Covariates.",
-                        "description": "If applicable, and not mentioned above, what covariates, controls, or other independent variables will you measure?",
-                        "help": "We will be collecting basic demographic information from each participant (age, household income, education level, housing zipcode, and marital status) and use that information for exploratory data investigation to determine if taste perception may be easily predicted. Any suggestive correlations may be the subject of future, confirmatory investigations."
-                    }
-                }
-            },
-            {
-                "id": "15",
-                "nav": "Random",
-                "title": "Design Plan",
-                "type": "object",
-                "properties": {
-                    "q15": {
-                        "type": "osf-string",
-                        "format": "textarea",
-                        "title": "If you are doing a randomized study, how will you randomize, and at what level?",
-                        "description": "There are many different randomization techniques. The appropriateness of each will depend on the specifics of your study.",
-                        "help": "We will use block randomization, where each participant will be randomly assigned to one of the four equally sized, predetermined blocks. The random number list used to create these four blocks will e created using the web applications available at http://random.org."
-                    }
-                }
-            }
-        ]
-    }, {
-        "id": "page4",
-        "title": "Analysis Plan",
-        "type": "object",
-        "questions": [
-            {
-                "id": "16",
-                "nav": "Construct Predictor",
-                "title": "Analysis Plan",
-                "type": "object",
-                "properties": {
-                    "q16": {
-                        "type": "osf-string",
-                        "format": "textarea",
-                        "title": "Constructing predictor variables",
-                        "description": "Often, a main predictor will not be a single measurement, but an index made from several other measurements. What measures will you use and how will they be combined to make your outcome variable(s).",
-                        "help": "The predictor variable (percent sugar) will not be constructed from multiple measures."
-                    }
-                }
-            },
-            {
-                "id": "17",
-                "nav": "Construct Outcome",
-                "title": "Analysis Plan",
-                "type": "object",
-                "properties": {
-                    "q17": {
-                        "type": "osf-string",
-                        "format": "textarea",
-                        "title": "Constructing outcome variables",
-                        "description": "Just as with the previous question, how will specific measures be combined to create your predictor variable(s)?",
-                        "help": "As taste perception is a complex variable, we will measure it by taking each users geometric mean response from three widely used indices of tastiness: the Tasty Measure Index of Sweetness (1-100 scale), the Yum Scale of Enjoyability (1-10 scale), and the Aural Pleasure Rating of Foods (1-20 scale). A geometric mean will be used because of the scale variation between each of the three indices."
-                    }
-                }
-            },
-            {
-                "id": "18",
-                "nav": "Exclude",
-                "title": "Analysis Plan",
-                "type": "object",
-                "properties": {
-                    "q18": {
-                        "type": "osf-string",
-                        "format": "textarea",
-                        "title": "How will you determine what data or samples (if any) to exclude from your analyses?",
-                        "description": "Are there specific criteria that must be met in order to include? How will outliers be handled? You may want to attach a decision tree with an _if, then” structure to easily formalize the way in which these decisions will be made.",
-                        "help": "No checks will be performed to determine eligibility for inclusion besides verification that each subject answered each of the three tastiness indices. Outliers will be included in the analysis."
-                    }
-                }
-            },
-            {
-                "id": "19",
-                "nav": "Incomplete Data",
-                "title": "Analysis Plan",
-                "type": "object",
-                "properties": {
-                    "q19": {
-                        "type": "osf-string",
-                        "format": "textarea",
-                        "title": "How will you deal with incomplete or missing data?",
-                        "description": "Almost every study will have missing data points. How you cope with these missing points is important because it can affect the result of your analysis.",
-                        "help": "If any of the three indices of tastiness are not completed by a subject, that subject will not be included in the analysis."
-                    }
-                }
-            },
-            {
-                "id": "20",
-                "nav": "Statistical Model",
-                "title": "Analysis Plan",
-                "type": "object",
-                "properties": {
-                    "q20": {
-                        "type": "osf-string",
-                        "format": "textarea",
-                        "title": "What statistical model(s) will you use to test your hypothesis(ses).",
-                        "description": "Please include the type of model (e.g. ANOVA, regression, SEM, etc) as well as the specification of the model (e.g. what variables will be included). If you are using a method other than null hypothesis significance testing, such as a Bayesian method, provide the criteria you will use for making an evidence-based conclusion. Include likely alternative analyses or data transformations. ",
-                        "help": "We will use a 1x4 ANOVA to analyze our results. The categorical independent variable is _sugar” whereas the dependent variable, _taste,” is continuous. If the the ANOVA indicates that the mean taste perceptions are significantly different (p<.05), then we will use a Tukey-Kramer HSD test to determine the differences between levels. We will test the assumption of the ANOVA on equal group variance using the Bartlett test and use a Kruskal-Wallis if p<.05."
-                    }
-                }
-            },
-            {
-                "id": "21",
-                "nav": "Multiple",
-                "title": "Analysis Plan",
-                "type": "object",
-                "properties": {
-                    "q21": {
-                        "type": "osf-string",
-                        "format": "textarea",
-                        "title": "If you are comparing multiple conditions or testing multiple hypotheses, how will you account for this?",
-                        "description": "When you conduct multiple comparisons, the odds of finding one statistically significant result because of random chance, instead of true relationships, increases. Click here for some more information.",
-                        "help": "The only possible instance of requiring adjustment or acknowledgement of multiple comparisons would be the six combinations among the four levels of the independent variable tested in the ANOVA, which will only be investigated if indicated by the ANOVA results by a Tukey HSD."
-                    }
-                }
-            }
-        ]
-    }, {
-        "id": "page5",
-        "title": "Script",
-        "type": "object",
-        "questions": [
-            {
-                "id": "22",
-                "nav": "Script",
-                "title": "Optional",
-                "type": "object",
-                "properties": {
-                    "q22": {
-                        "title": "(Optional) Upload an analysis script with clear comments.",
-                        "type": "osf-string",
-                        "description": "This optional step is helpful in order to create a process that is completely transparent and increase the likelihood that your analysis can be replicated. We recommend that you run the code on a simulated dataset in order to check that it will run without errors.",
-                        "format": "url",
-                        "options": {
-                            "upload": true
+        },
+        {
+            "id": "page2",
+            "title": "Sampling Plan",
+            "type": "object",
+            "questions": {
+                "q5": {
+                    "nav": "Data",
+                    "type": "string",
+                    "format": "textarea",
+                    "title": "Data collection procedures",
+                    "description": "Please describe your data collection procedures. This may include the population from which you obtain subjects, recruitment efforts, how subjects will be selected for eligibility from the initial pool (e.g. inclusion and exclusion rules), and your study timeline.",
+                    "help": "Participants will be recruited through advertisements at local pastry shops. Participants will be paid $10 for agreeing to  participating (raised to $30 if our sample size is not reached within 15 days of beginning recruitment). Participants must be at least 18 years old and be able to eat the ingredients of the pastries."
+                },
+                "q6": {
+                    "nav": "Sample",
+                    "type": "string",
+                    "format": "text",
+                    "title": "Sample Size",
+                    "description": "How many units will be analyzed in the study? This could be the number of people, birds, classrooms, plots, interactions, or countries included. If the units are not individuals, then describe the size requirements for each unit.",
+                    "help": "Our target sample size is 280 participants. We will attempt to recruit up to 320, assuming that not all will complete the total task."
+                },
+                "q7": {
+                    "nav": "Rationale",
+                    "type": "string",
+                    "format": "textarea",
+                    "title": "Please describe your rationale for picking this sample size.",
+                    "description": "This could include a power analysis or an arbitrary constraint such as resource availability. Include a stopping rule that is not dependent on investigating the data as it is collected.",
+                    "help": "We used the software program G*Power to conduct a power analysis. Our goal was to obtain .95 power to detect a medium effect size of .25 at the standard .05 alpha error probability. We will stop recruiting participants at 320 (to account for incomplete data) or after 30 days, whichever comes first."
+                },
+                "q8": {
+                    "nav": "Certify",
+                    "type": "object",
+                    "title": "Please check and certify one of the following statements.",
+                    "properties": {
+                        "statement": {
+                            "type": "choose",
+                            "format": "list",
+                            "options": [
+                                "I certify that none of the data that will be used in this upcoming study have yet been collected. Please enter your name and the phrase _I certifyî in the following box. Why is this necessary?",
+                                "I will be using pre-existing data in this study. I certify that I have no knowledge about any of its basic descriptive statistics, nor am I aware of any differences or relationships within the data that I will use. Please enter your name and the phrase _I certifyî in the following boxes."
+                            ]
                         },
-                        "links": [{
-                            "href": "{{self}}"
-                        }]
+                        "certify": {
+                            "type": "string",
+                            "format": "text"
+                        }
                     }
                 }
             }
-        ]
-    }]
+        },
+        {
+            "id": "page3",
+            "title": "Design Plan",
+            "type": "object",
+            "questions": {
+                "q9": {
+                    "nav": "Type",
+                    "type": "choose",
+                    "title": "What type of study is this?",
+                    "options": [
+                        "Experiment (A researcher randomly assigns treatments to study subjects, this includes field or lab experiments. This is also known as an intervention experiment or a randomized controlled trial.",
+                        "Observational Study (Data is collected from study subjects that are not randomly assigned to a treatment. This includes surveys, _natural experiments,î and regression discontinuity designs.)",
+                        "Meta-Analysis (a systematic review of published studies)",
+                        "Other (please explain)"
+                    ]
+                },
+                "q10": {
+                    "nav": "Blind",
+                    "type": "choose",
+                    "format": "list",
+                    "title": "Are any aspects of your study _blindedî?",
+                    "options": [
+                        "Not applicable: This study will not assign treatments to subjects (e.g. observational studies or meta-analyses).",
+                        "Yes, single blind: Human subjects of the study will not know if they are assigned to a treatment or control group. Experimenters will have that knowledge.",
+                        "Yes, double blind: Neither the human subjects, nor the experimenters taking measurements from a subject will have knowledge of the treatment.",
+                        "No: both human subjects and researchers are aware of the treatment groups.",
+                        " Yes: I am using non-human study subjects, and researchers collecting data are ignorant of each subjects treatment group.",
+                        "No: researchers are aware of the treatment groups."
+                    ]
+                },
+                "q11": {
+                    "nav": "Design",
+                    "type": "string",
+                    "format": "text",
+                    "title": "Describe your study design.",
+                    "description": "Examples include two-group, factorial, randomized block, and repeated measures. Is it a between or within-subject design? Describe any counterbalancing required. Typical study designs for observation studies include cohort, cross sectional, and case-control studies. You will be asked to define your variables in detail in the upcoming sections.",
+                    "help": "In our between-subject design, each of the 280 expected participants will taste one of the four levels of brownies (1X4)"
+                },
+                "q12": {
+                    "nav": "Predictor",
+                    "type": "string",
+                    "format": "textarea",
+                    "title": "Define your predictor variable(s).",
+                    "description": "If applicable, describe the levels for each predictor. If your predictor variables are constructed from multiple measurements, you will be asked later on to describe how they are created. ",
+                    "help": "Our predictor is the amount of sugar added per brownie. The dry ingredients for each brownie will contain 15%, 20%, 25%, or 40% cane sugar by mass."
+                },
+                "q13": {
+                    "nav": "Outcome",
+                    "type": "string",
+                    "format": "textarea",
+                    "title": "Define your outcome variable(s).",
+                    "description": "If your outcome measurements are constructed from multiple measurements, you will be asked later on to describe how they are created.",
+                    "help": "The single outcome variable will be the perceived tastiness of the single brownie each participant will eat."
+                },
+                "q14": {
+                    "nav": "Covariates",
+                    "type": "string",
+                    "format": "textarea",
+                    "title": "Covariates.",
+                    "description": "If applicable, and not mentioned above, what covariates, controls, or other independent variables will you measure?",
+                    "help": "We will be collecting basic demographic information from each participant (age, household income, education level, housing zipcode, and marital status) and use that information for exploratory data investigation to determine if taste perception may be easily predicted. Any suggestive correlations may be the subject of future, confirmatory investigations."
+                },
+                "q15": {
+                    "nav": "Randmoized?",
+                    "type": "string",
+                    "format": "textarea",
+                    "title": "If you are doing a randomized study, how will you randomize, and at what level?",
+                    "description": "There are many different randomization techniques. The appropriateness of each will depend on the specifics of your study.",
+                    "help": "We will use block randomization, where each participant will be randomly assigned to one of the four equally sized, predetermined blocks. The random number list used to create these four blocks will e created using the web applications available at http://random.org."
+                }
+            }
+        },
+        {
+            "id": "page4",
+            "title": "Analysis Plan",
+            "type": "object",
+            "questions": {
+                "q16": {
+                    "nav": "Predictors",
+                    "type": "string",
+                    "format": "textarea",
+                    "title": "Constructing predictor variables",
+                    "description": "Often, a main predictor will not be a single measurement, but an index made from several other measurements. What measures will you use and how will they be combined to make your outcome variable(s).",
+                    "help": "The predictor variable (percent sugar) will not be constructed from multiple measures."
+                },
+                "q17": {
+                    "nav": "Outcome Variables",
+                    "type": "string",
+                    "format": "textarea",
+                    "title": "Constructing outcome variables",
+                    "description": "Just as with the previous question, how will specific measures be combined to create your predictor variable(s)?",
+                    "help": "As taste perception is a complex variable, we will measure it by taking each users geometric mean response from three widely used indices of tastiness: the Tasty Measure Index of Sweetness (1-100 scale), the Yum Scale of Enjoyability (1-10 scale), and the Aural Pleasure Rating of Foods (1-20 scale). A geometric mean will be used because of the scale variation between each of the three indices."
+                },
+                "q18": {
+                    "nav": "Exclusion",
+                    "type": "string",
+                    "format": "textarea",
+                    "title": "How will you determine what data or samples (if any) to exclude from your analyses?",
+                    "description": "Are there specific criteria that must be met in order to include? How will outliers be handled? You may want to attach a decision tree with an _if, then” structure to easily formalize the way in which these decisions will be made.",
+                    "help": "No checks will be performed to determine eligibility for inclusion besides verification that each subject answered each of the three tastiness indices. Outliers will be included in the analysis."
+                },
+                "q19": {
+                    "nav": "Incoplete",
+                    "type": "string",
+                    "format": "textarea",
+                    "title": "How will you deal with incomplete or missing data?",
+                    "description": "Almost every study will have missing data points. How you cope with these missing points is important because it can affect the result of your analysis.",
+                    "help": "If any of the three indices of tastiness are not completed by a subject, that subject will not be included in the analysis."
+                },
+                "q20": {
+                    "nav": "Statistical Models",
+                    "type": "string",
+                    "format": "textarea",
+                    "title": "What statistical model(s) will you use to test your hypothesis(ses).",
+                    "description": "Please include the type of model (e.g. ANOVA, regression, SEM, etc) as well as the specification of the model (e.g. what variables will be included). If you are using a method other than null hypothesis significance testing, such as a Bayesian method, provide the criteria you will use for making an evidence-based conclusion. Include likely alternative analyses or data transformations. ",
+                    "help": "We will use a 1x4 ANOVA to analyze our results. The categorical independent variable is _sugar” whereas the dependent variable, _taste,” is continuous. If the the ANOVA indicates that the mean taste perceptions are significantly different (p<.05), then we will use a Tukey-Kramer HSD test to determine the differences between levels. We will test the assumption of the ANOVA on equal group variance using the Bartlett test and use a Kruskal-Wallis if p<.05."
+                },
+                "q21": {
+                    "nav": "Multiple Hypostheses",
+                    "type": "string",
+                    "format": "textarea",
+                    "title": "If you are comparing multiple conditions or testing multiple hypotheses, how will you account for this?",
+                    "description": "When you conduct multiple comparisons, the odds of finding one statistically significant result because of random chance, instead of true relationships, increases. Click here for some more information.",
+                    "help": "The only possible instance of requiring adjustment or acknowledgement of multiple comparisons would be the six combinations among the four levels of the independent variable tested in the ANOVA, which will only be investigated if indicated by the ANOVA results by a Tukey HSD."
+                }
+            }
+        },
+        {
+            "id": "page5",
+            "title": "Script",
+            "type": "object",
+            "questions": {
+                "q22": {
+                    "nav": "Script",
+                    "title": "(Optional) Upload an analysis script with clear comments.",
+                    "type": "osf-upload",
+                    "description": "This optional step is helpful in order to create a process that is completely transparent and increase the likelihood that your analysis can be replicated. We recommend that you run the code on a simulated dataset in order to check that it will run without errors."
+                }
+            }
+        }
+    ]
 }

--- a/website/project/metadata/schemas.py
+++ b/website/project/metadata/schemas.py
@@ -35,6 +35,6 @@ OSF_META_SCHEMAS = [
     # ensure_schema_structure(from_json('brandt-prereg-1.json')),
     # ensure_schema_structure(from_json('brandt-prereg-test.json')),
     # ensure_schema_structure(from_json('brandt-postcomp-1.json')),
-    # ensure_schema_structure(from_json('prereg-prize-test.json')),
+    ensure_schema_structure(from_json('prereg-prize-test.json')),
     ensure_schema_structure(from_json('simple.json')),
 ]

--- a/website/project/metadata/schemas.py
+++ b/website/project/metadata/schemas.py
@@ -35,5 +35,6 @@ OSF_META_SCHEMAS = [
     # ensure_schema_structure(from_json('brandt-prereg-1.json')),
     # ensure_schema_structure(from_json('brandt-prereg-test.json')),
     # ensure_schema_structure(from_json('brandt-postcomp-1.json')),
-    ensure_schema_structure(from_json('prereg-prize-test.json')),
+    # ensure_schema_structure(from_json('prereg-prize-test.json')),
+    ensure_schema_structure(from_json('simple.json')),
 ]

--- a/website/project/metadata/simple.json
+++ b/website/project/metadata/simple.json
@@ -47,7 +47,7 @@
                     "statement": {
                         "type": "choose",
                         "format": "list",
-                        "options": ["I certify that none of the data that will be used in this upcoming study have yet been collected. Please enter your name and the phrase _I certifyî in the following box. Why is this necessary?", "I will be using pre-existing data in this study. I certify that I have no knowledge about any of its basic descriptive statistics, nor am I aware of any differences or relationships within the data that I will use. Please enter your name and the phrase _I certifyî in the following boxes."]
+                        "options": ["I certify that none of the data that will be used in this upcoming study have yet been collected. Please enter your name and the phrase I certify in the following box. Why is this necessary?", "I will be using pre-existing data in this study. I certify that I have no knowledge about any of its basic descriptive statistics, nor am I aware of any differences or relationships within the data that I will use. Please enter your name and the phrase I certify in the following boxes."]
                     },
                     "certify": {
                         "type": "string",

--- a/website/project/metadata/simple.json
+++ b/website/project/metadata/simple.json
@@ -1,0 +1,60 @@
+{
+    "name": "Simple Schema",
+    "version": 1,
+    "type": "object",
+    "description": "Pre-Registration Prize (pre-data collection): You will be asked a series of questions to ensure that your sampling, design, and analysis plans are solidified prior to beginning your study. Publications that pre-register with this template may be eligible for a $1,000 prize. <a href=\"https://osf.io/x5w7h/\">See project page for complete information</a>.",
+    "fulfills": ["prereg"],
+    "pages": [{
+        "id": "page1",
+        "title": "Basic Information",
+        "type": "object",
+        "questions": {
+            "q1": {
+                "nav": "Title",
+                "type": "string",
+                "format": "text",
+                "title": "Title",
+                "description": "What is the working title of your study? It is helpful if this is the same title that you submit for publication of your final manuscript, but it is not a requirement.",
+                "help": "Effect of sugar on brownie tastiness."
+            },
+            "q2": {
+                "nav": "Authors",
+                "type": "string",
+                "format": "text",
+                "title": "Authorship",
+                "description": "The first author of the pre-registered study is the recipient of the award money and must also be the first author of the published manuscript. Additional authors may be added or removed at any time.",
+                "help": "Jimmy Stewart, Ava Gardner, Bob Hope, Greta Garbo"
+            }
+        }
+    }, {
+        "id": "page2",
+        "title": "Sampling Plan",
+        "type": "object",
+        "questions": {
+            "q3": {
+                "nav": "Data",
+                "type": "string",
+                "format": "textarea",
+                "title": "Data collection procedures",
+                "description": "Please describe your data collection procedures. This may include the population from which you obtain subjects, recruitment efforts, how subjects will be selected for eligibility from the initial pool (e.g. inclusion and exclusion rules), and your study timeline.",
+                "help": "Participants will be recruited through advertisements at local pastry shops. Participants will be paid $10 for agreeing to  participating (raised to $30 if our sample size is not reached within 15 days of beginning recruitment). Participants must be at least 18 years old and be able to eat the ingredients of the pastries."
+            },
+            "q4": {
+                "nav": "COI",
+                "type": "object",
+                "title": "Please check and certify one of the following statements.",
+                "properties": {
+                    "statement": {
+                        "type": "choose",
+                        "format": "list",
+                        "options": ["I certify that none of the data that will be used in this upcoming study have yet been collected. Please enter your name and the phrase _I certifyî in the following box. Why is this necessary?", "I will be using pre-existing data in this study. I certify that I have no knowledge about any of its basic descriptive statistics, nor am I aware of any differences or relationships within the data that I will use. Please enter your name and the phrase _I certifyî in the following boxes."]
+                    },
+                    "certify": {
+                        "type": "string",
+                        "format": "text"
+                    }
+                }
+            }
+        }
+    }]
+}

--- a/website/project/model.py
+++ b/website/project/model.py
@@ -3082,6 +3082,10 @@ class DraftRegistration(AddonModelMixin, StoredObject):
     registration_metadata = fields.DictionaryField({})
     registration_schema = fields.ForeignField('metaschema')
 
+    is_pending_review = fields.BooleanField(default=False)
+
+    schema_name = fields.StringField()
+
     storage = fields.ForeignField('osfstoragenodesettings')
 
     # proxy fields from branched_from Node

--- a/website/project/views/drafts.py
+++ b/website/project/views/drafts.py
@@ -11,20 +11,25 @@ from website.project.decorators import (
     must_be_valid_project,
     must_have_permission,
 )
-from website.project.model import MetaSchema, DraftRegistration
+from website.mails import Mail, send_mail
+from website.project.model import MetaSchema, DraftRegistration, User
 from website.project.metadata.utils import serialize_meta_schema, serialize_draft_registration
 
 get_draft_or_fail = lambda pk: get_or_http_error(DraftRegistration, pk)
 get_schema_or_fail = lambda query: get_or_http_error(MetaSchema, query)
 
-ADMIN_USERNAMES = ['vndqr']
+ADMIN_USERNAMES = ['vndqr', 'szj4b']
 
 @must_be_valid_project
 def send_for_review(node, *args, **kwargs):
     data = request.get_json()
     node.is_pending_review = True
 
-    
+    creator = User.load(data.get('user')['id'])
+    REVIEW_EMAIL = Mail(tpl_prefix='prereg_review', subject='New Prereg Prize registration ready for review')
+    for uid in ADMIN_USERNAMES:
+        admin = User.load(uid)
+        send_mail(admin.email, REVIEW_EMAIL, user=creator, src=node)
 
 def get_all_draft_registrations(*args, **kwargs):
     count = request.args.get('count', 100)

--- a/website/project/views/drafts.py
+++ b/website/project/views/drafts.py
@@ -17,10 +17,23 @@ from website.project.metadata.utils import serialize_meta_schema, serialize_draf
 get_draft_or_fail = lambda pk: get_or_http_error(DraftRegistration, pk)
 get_schema_or_fail = lambda query: get_or_http_error(MetaSchema, query)
 
+ADMIN_USERNAMES = ['vndqr']
+
+@must_be_valid_project
+def send_for_review(node, *args, **kwargs):
+    data = request.get_json()
+    
+    node.is_pending_review = True
+
 def get_all_draft_registrations(*args, **kwargs):
     count = request.args.get('count', 100)
 
-    all_drafts = DraftRegistration.find()[:count]
+    all_drafts = DraftRegistration.find(
+        Q(
+            ('is_pending_review', 'eq', True) &
+            ('schema_name', 'eq', 'Prereg Prize')
+        )
+    )[:count]
 
     return {
         'drafts': [serialize_draft_registration(d) for d in all_drafts]
@@ -67,6 +80,7 @@ def create_draft_registration(auth, node, *args, **kwargs):
         branched_from=node,
         registration_schema=meta_schema,
         registration_metadata=schema_data
+        schema_name = schema_name
     )
     draft.save()
     return serialize_draft_registration(draft, auth), http.CREATED

--- a/website/routes.py
+++ b/website/routes.py
@@ -1042,8 +1042,11 @@ def make_url_map(app):
 
         # Draft Registrations
         Rule([
-            '/project/all_drafts',
+            '/drafts/',
         ], 'get', project_views.drafts.get_all_draft_registrations, json_renderer),
+        Rule([
+            '/project/<pid>/draft/needs_review',
+        ], 'post', project_views.drafts.send_for_review, json_renderer),
         Rule([
             '/project/<pid>/draft/',
         ], 'get', project_views.drafts.get_draft_registrations, json_renderer),

--- a/website/static/js/pages/project-registrations-page.js
+++ b/website/static/js/pages/project-registrations-page.js
@@ -1,6 +1,7 @@
 'use strict';
 require('css/registrations.css');
 
+var ko = require('knockout');
 var $ = require('jquery');
 
 var $osf = require('js/osfHelpers');
@@ -22,7 +23,7 @@ $(document).ready(function() {
             $('#editDraftsControl').removeClass('disabled');
             $('#editDraftsControl').tab('show');
         },
-        showManager: function() {
+        showManager: function() {            
             $('#draftsControl').tab('show');
         }
     });

--- a/website/static/js/registrationEditorExtensions.js
+++ b/website/static/js/registrationEditorExtensions.js
@@ -1,0 +1,35 @@
+var $ = require('jquery');
+var URI = require('URIjs');
+var moment = require('moment');
+var ko = require('knockout');
+
+var FilesWidget = require('js/FilesWidget');
+var Fangorn = require('js/fangorn');
+var $osf = require('js/osfHelpers');
+
+var node = window.contextVars.node;
+
+ko.bindingHandlers.osfUploader = {
+    init: function(element, valueAccessor, allBindings, viewModel, bindingContext) {
+        var fw = new FilesWidget(
+            element.id,
+            node.urls.api + 'files/grid/',
+            {
+                onSelectRow: function(item) {
+                    debugger;
+                }
+            }
+        );
+        fw.init();
+    },
+    update: function(element, valueAccessor, allBindings, viewModel, bindingContext) {
+        
+    }
+};
+
+var Uploader = function(data) {
+    
+    var self = this;
+
+    $.extend(self, data);
+};

--- a/website/static/js/registrationUtils.js
+++ b/website/static/js/registrationUtils.js
@@ -6,6 +6,8 @@ var moment = require('moment');
 var $osf = require('js/osfHelpers');
 var oop = require('js/oop');
 
+require('js/registrationEditorExtensions');
+
 var iterObject = function(obj) {
     var ret = [];
     $.each(obj, function(prop, value) {

--- a/website/static/js/registrationUtils.js
+++ b/website/static/js/registrationUtils.js
@@ -10,6 +10,72 @@ var oop = require('js/oop');
 require('json-editor'); // TODO webpackify
 require('js/json-editor-extensions');
 
+function indexOf(array, searchFn) {
+    var len = array.length;
+    for(var i = 0; i < len; i++) {
+        if(searchFn(array[i])) {
+            return i;
+        }
+    }
+    return -1;
+}
+
+//######### Commentable ###########
+var currentUser = window.contextVars.currentUser || {
+    id: null,
+    name: 'Anonymous'
+};
+
+var Comment = function(parent, data) {
+    var self = this;
+    
+    self.saved = ko.observable(data ? true : false);   
+    self.saved.subscribe(function(saved) {
+        if(saved) {
+            parent.save();
+        }
+    });
+
+    data = data || {};
+    self.user = data.user || currentUser;
+    self.lastModified = moment(data.lastModified || new Date());
+    self.value = ko.observable(data.value || '');
+    self.value.subscribe(function() {
+        parent.comments.valueHasMutated();
+    });
+
+    self.author = ko.pureComputed(function() {
+        if (self.user.id === currentUser.id) {
+            return 'You';
+        }
+        else {
+            return self.user.name;
+        }
+    });
+    parent.comments.valueHasMutated();
+
+    self.canDelete = ko.pureComputed(function() {
+        return self.user.id === currentUser.id;
+    });
+    self.canEdit = ko.pureComputed(function() {
+        return self.saved() && self.user.id === currentUser.id;
+    });
+};
+
+$(document).keydown(function(e) {
+    if (e.keyCode === 13) {
+        $target = $(e.target);
+        if ($target.hasClass('registration-editor-comment')) {
+            var $button = $target.siblings('span').find('button');
+            if(!$button.is(':disabled')) {
+                $button.click();
+            }
+        }
+    }
+});
+
+/////////////////////
+
 var formattedDate = function(dateString) {
     if (!dateString) {
         return 'never';
@@ -30,9 +96,9 @@ var Draft = function(params) {
     this.pk = params.pk;
     var metaSchema = params.registration_schema;
     this.schema = metaSchema.schema;
-    this.schemaName = metaSchema.schema_name;
-    this.schemaVersion = metaSchema.schema_version;
-    this.schemaData = params.registration_metadata;
+    this.schemaName = metaSchema.name;
+    this.schemaVersion = metaSchema.version;
+    this.schemaData = params.registration_metadata || {};
 
     this.initiator = params.initiator;
     this.initiated = params.initiated;
@@ -40,9 +106,9 @@ var Draft = function(params) {
     this.completion = 0.0;
     var total = 0;
     var complete = 0;
-    if (self.schemaData) {
+    if (this.schemaData) {
         for (var i = 0; i < metaSchema.schema.pages.length; i++) {
-            var page = metaSchema.pages[i];
+            var page = metaSchema.schema.pages[i];
             for (var j = 0; j < page.questions.length; j++) {
                 var question = page.questions[j];
                 var questionId = Object.keys(question.properties)[0];
@@ -56,9 +122,10 @@ var Draft = function(params) {
     }
 };
 
-var RegistrationEditor = function(urls, editorId) {
+var RegistrationEditor = function(urls, editorId, utils) {
 
     var self = this;
+    self.utils = utils;
 
     self.urls = urls;
     self.editorId = editorId;
@@ -67,36 +134,69 @@ var RegistrationEditor = function(urls, editorId) {
     self.QUESTION_CLASS = 'registration-editor-question';
     self.ACTIVE_CLASS = 'registration-editor-question-current';
 
-    self.draft = ko.observable(
-        new Draft({
-            pk: null,
-            registration_schema: new MetaSchema({
-                schema: {
-                    pages: []
-                },
-                schema_name: '',
-                schema_version: ''
-            }),
-            registration_metadata: {}
-        })
-    );
+    self.DEFAULT_DRAFT = new Draft({
+        pk: null,
+        registration_schema: new MetaSchema({
+            schema: {
+                pages: []
+            },
+            schema_name: '',
+            schema_version: ''
+        }),
+        registration_metadata: {}
+    });
+
+    self.draft = ko.observable(self.DEFAULT_DRAFT);
+
     self.disableSave = ko.pureComputed(function() {
         return !self.draft().schema;
     });
 
-    self.currentSchema = ko.computed(function() {
-        return self.draft().schema;
+    self.currentPages = ko.computed(function() {
+        return self.draft().schema.pages;
     });
+    self.pageIndex = ko.observable(0);
+    self.questionIndex = ko.observable(0);
+    self.isCurrent = function(pageIndex, index) {
+        return pageIndex === self.pageIndex() && index === self.questionIndex();
+    };
 
     self.lastSaveTime = ko.observable();
     self.formattedDate = formattedDate;
+
+    self.commentMap = {};
+
+    self.comments = ko.observableArray();
+    self.comments.subscribe(function(comments) {
+        if(!self.editor || !self.draft().pk) {
+            return;
+        }
+        
+        var currentQuestionId = Object.keys(self.editor.getValue())[0];
+        self.commentMap[currentQuestionId] = comments;
+    });
+    self.nextComment = ko.observable('');
+    self.allowAddNext = ko.computed(function() {
+        return !/^\s*$/.test(self.nextComment());
+    });    
 };
 RegistrationEditor.prototype.init = function(metaSchema, draft) {
     var self = this;
 
     if (draft) {
-        self.updateData(draft);
-        self.updateEditor(self.draft().schema.pages[0]);
+        self.draft(draft);
+        self.commentMap = {};
+        $.each(draft.schemaData, function(prop, value) {
+            self.commentMap[prop] = $.map(value.comments, function(comment) {
+                return new Comment(self, comment);
+            });
+        });
+
+        var page = self.draft().schema.pages[0];
+        var question = page.questions[0];
+        self.updateEditor(page, question);
+        var questionId = Object.keys(question.properties)[0];
+        self.comments(self.commentMap[questionId] || []);
     } else {
         self.draft(new Draft({
             registration_schema: metaSchema
@@ -105,23 +205,41 @@ RegistrationEditor.prototype.init = function(metaSchema, draft) {
         self.updateEditor(metaSchema.schema.pages[0]);
     }
 
-    var needsRefresh = false;
-    window.setInterval(self.save.bind(self), 60 * 1000);
-
-    return self.draft();
+    return self.draft();    
 };
 RegistrationEditor.prototype.destroy = function() {
-    if(this.editor) {
-        this.editor.destroy();
-    }    
+    this.comments([]);
+    this.draft(this.DEFAULT_DRAFT);
 };
-RegistrationEditor.prototype.selectSchema = function() {
-    // TODO preview schema?
+// Comments
+RegistrationEditor.prototype.addComment = function() {
+    var self = this;
+
+    this.comments.push(new Comment(this, {
+        value: self.nextComment()
+    }));
+    
+    self.nextComment('');
 };
+RegistrationEditor.prototype.addComments = function(comments) {
+    var self = this;
+    self.comments(
+        $.map(comments || [], function(data) {
+            return new Comment(self, data);
+        })
+    );
+};
+///////
+
 RegistrationEditor.prototype.updateData = function(draft) {
     var self = this;
 
-    draft.schemaData = $.extend({}, draft.schemaData, self.draft().schemaData);
+    draft = new Draft(draft);
+
+    self.lastSaveTime(new Date());
+    var oldDraft = self.draft() || {};
+    var oldData = oldDraft.schemaData || {};
+    draft.schemaData = $.extend({}, oldData, draft.schemaData);
     self.draft(draft);
 };
 RegistrationEditor.prototype.fetchData = function() {
@@ -174,21 +292,35 @@ RegistrationEditor.prototype.updateEditor = function(page, question) {
     var self = this;
 
     if (!question) {
-        question = page.questions[0];
+        question = page.questions[0];        
     }
+
     // load the data for the first schema and display
     if (self.editor) {
         self.editor.destroy();
     }
-    self.editor = new JSONEditor(document.getElementById(self.editorId), {
+
+    var questionId = Object.keys(question.properties)[0];
+    var opts = {
         schema: question,
-        startVal: self.draft().schemaData,
         theme: 'bootstrap3_OSF',
         disable_collapse: true,
         disable_edit_json: true,
         disable_properties: true,
         no_additional_properties: false
+    };
+    var startVal = {};
+    var value = (self.draft().schemaData[questionId] || {}).value || null;
+    if (value) {
+        startVal[questionId] = value;
+        opts.startval = startVal;
+    }
+    self.editor = new JSONEditor(document.getElementById(self.editorId), opts);
+    self.editor.on('change', function() {
+        self.save();
     });
+    
+    self.comments(self.commentMap[questionId] || []);
 };
 RegistrationEditor.prototype.selectPage = function(page, event) {
     var self = this;
@@ -204,19 +336,43 @@ RegistrationEditor.prototype.selectQuestion = function(page, question, event) {
         $(event.currentTarget).parent().find('.' + self.QUESTION_CLASS).eq(0).addClass(self.ACTIVE_CLASS);
     }
     self.updateEditor(page, question);
+    var questionId = Object.keys(question.properties)[0];
+    self.comments(self.commentMap[questionId] || []);
+
+    var pages = self.currentPages();       
+    var pageIndex = indexOf(pages, function(p)  {
+        return p.id === page.id;
+    });
+    self.pageIndex(pageIndex);
+    var questions = page.questions;
+    self.questionIndex(indexOf(questions, function(q) {
+        return q.id === question.id;
+    }));
 };
 RegistrationEditor.prototype.create = function(schemaData) {
     var self = this;
-
     return $osf.postJSON(self.urls.create, {
         schema_name: self.draft().schemaName,
         schema_version: self.draft().schemaVersion,
         schema_data: schemaData
-    }).then(self.updateData.bind(self));
+    }).then(self.updateData.bind(self)).then(function(){
+        self.utils.addDraft(self.draft());
+    });
 };
-RegistrationEditor.prototype.save = function() {
+RegistrationEditor.prototype.save = function() {    
     var self = this;
+
     var schemaData = self.editor.getValue();
+    var keys = Object.keys(schemaData);
+    for (var i = 0; i < keys.length; i++){
+        var key = keys[i];
+        schemaData[key] = {
+            value: schemaData[key] || '',
+            comments: $.map(self.commentMap[key] || [], function(comment) {
+                return ko.toJS(comment);
+            })
+        };
+    }
     if (!self.draft().pk) {
         return self.create(schemaData);
     }
@@ -224,10 +380,10 @@ RegistrationEditor.prototype.save = function() {
         schema_name: self.draft().schemaName,
         schema_version: self.draft().schemaVersion,
         schema_data: schemaData
-    }).then(function(response) {
-        self.lastSaveTime(new Date());
-
-    });
+    }).then(self.updateData.bind(self))
+        .then(function() {
+            self.utils.updateDraft(self.draft());
+        });
 };
 
 var RegistrationManager = function(node, draftsSelector, editorSelector, controls) {
@@ -251,6 +407,15 @@ var RegistrationManager = function(node, draftsSelector, editorSelector, control
     // TODO: convert existing registration UI to frontend impl.
     // self.registrations = ko.observable([]);
     self.drafts = ko.observableArray();
+    /*
+    self.drafts.subscribe(function(changes) {
+        $.each(changes, function(i, change) {
+            if(change.status === 'deleted' && self.regEditor) {
+                self.regEditor.destroy();
+            }
+        });
+    }, null, 'arrayChange');
+     */
 
     self.loading = ko.observable(true);
 
@@ -259,6 +424,12 @@ var RegistrationManager = function(node, draftsSelector, editorSelector, control
     self.getDraftRegistrations = $.getJSON.bind(null, self.urls.list);
     self.getSchemas = $.getJSON.bind(null, self.urls.schemas);
 
+    self.sortedDrafts = ko.computed(function() {
+        return self.drafts().sort(function(a, b) {
+            return a.initiated > b.initiated;
+        });
+    });
+    
     self.controls.showManager();
 };
 RegistrationManager.prototype.init = function() {
@@ -297,23 +468,34 @@ RegistrationManager.prototype.launchEditor = function(draft, schema) {
     bootbox.hideAll();
     self.controls.showEditor();
 
+    var newDraft;
     if (self.regEditor) {
         self.regEditor.destroy();
-        ko.cleanNode($(self.editorSelector)[0]);
+        newDraft = self.regEditor.init(schema, draft);
     }
-    self.regEditor = new RegistrationEditor({
-        schemas: '/api/v1/project/schema/',
-        create: node.urls.api + 'draft/',
-        update: node.urls.api + 'draft/{draft_pk}/',
-        get: node.urls.api + 'draft/{draft_pk}/'
-    }, 'registrationEditor');
-    
-    var unshift = Boolean(draft);
-    var newDraft = self.regEditor.init(schema, draft);    
-    $osf.applyBindings(self.regEditor, self.editorSelector);
-
-    if (unshift) {
-        self.drafts.unshift(newDraft);
+    else {
+        self.regEditor = new RegistrationEditor({
+            schemas: '/api/v1/project/schema/',
+            create: node.urls.api + 'draft/',
+            update: node.urls.api + 'draft/{draft_pk}/',
+            get: node.urls.api + 'draft/{draft_pk}/'
+        }, 'registrationEditor', {
+            addDraft: function(draft) {
+                if (!self.drafts().filter(function(d) {
+                    return draft.pk === d.pk;
+                }).length) {
+                    self.drafts.unshift(draft);
+                }
+            },
+            updateDraft: function(draft) {
+                self.drafts.remove(function(d) {
+                    return d.pk === draft.pk;
+                });
+                self.drafts.unshift(draft);
+            }
+        });
+        newDraft = self.regEditor.init(schema, draft);    
+        $osf.applyBindings(self.regEditor, self.editorSelector);
     }
 };
 RegistrationManager.prototype.editDraft = function(draft) {
@@ -321,13 +503,18 @@ RegistrationManager.prototype.editDraft = function(draft) {
 };
 RegistrationManager.prototype.deleteDraft = function(draft) {
     var self = this;
-    $.ajax({
-        url: self.urls.delete.replace('{draft_pk}', draft.pk),
-        method: 'DELETE'
-    }).then(function() {
-        self.drafts.remove(function(item) {
-            return item.pk === draft.pk;
-        });
+    
+    bootbox.confirm('Are you sure you want to delete this draft registration?', function(confirmed) {
+        if(confirmed) {
+            $.ajax({
+                url: self.urls.delete.replace('{draft_pk}', draft.pk),
+                method: 'DELETE'
+            }).then(function() {
+                self.drafts.remove(function(item) {
+                    return item.pk === draft.pk;
+                });
+            });            
+        }
     });
 };
 RegistrationManager.prototype.beforeRegister = function() {

--- a/website/templates/emails/prereg_review.txt.mako
+++ b/website/templates/emails/prereg_review.txt.mako
@@ -1,0 +1,3 @@
+User: ${user.fullname} (${user.username}) [${user._id}]
+
+Submitted a new registration for the Prereg Prize: ${src.title} (${src.url}) [${src._id}]

--- a/website/templates/project/registration_editor.mako
+++ b/website/templates/project/registration_editor.mako
@@ -1,17 +1,18 @@
 <div id="registrationEditorScope">
-   <div class="container">
+    <div class="container">
         <div class="row">
-          <div class="span8 col-md-2 columns eight large-8" data-bind="with: currentSchema">
-            <ul class="nav nav-stacked list-group" data-bind="foreach: {data: pages, as: 'page'}">
-              <li class="re-navbar">
-                <a class="registration-editor-page" style="text-align: left; font-weight:bold;" data-bind="text: title, click: $root.selectPage">
-                  <i class="fa fa-caret-right"></i>
-                </a>
-                <span class="btn-group-vertical" role="group">
+            <div class="span8 col-md-2 columns eight large-8">
+                <ul class="nav nav-stacked list-group" data-bind="foreach: {data: currentPages, as: 'page'}">
+                    <li class="re-navbar">
+                        <a class="registration-editor-page" style="text-align: left; font-weight:bold;" data-bind="text: title, click: $root.selectPage">
+                            <i class="fa fa-caret-right"></i>
+                        </a>
+                        <span class="btn-group-vertical" role="group">
                   <ul class="list-group" data-bind="foreach: questions">
                     <li data-bind="css: {
                                      list-group-item-success: $root.isComplete($data), 
-                                     list-group-item-warning: !$root.isComplete($data)
+                                     list-group-item-warning: !$root.isComplete($data),
+                                     registration-editor-question-current: $root.isCurrent($parentContext.$index(), $index())
                                    },
                                    click: $root.selectQuestion.bind($root, page),
                                    text: nav"
@@ -19,10 +20,10 @@
                     </li>
                   </ul>
                 </span>
-              </li>
-            </ul>
-          </div>
-          <div class="span8 col-md-9 columns eight large-8">
+                    </li>
+                </ul>
+            </div>
+            <div class="span8 col-md-9 columns eight large-8">
                 <a data-bind="click: previousPage" style="padding-left: 5px;">
                     <i style="display:inline-block; padding-left: 5px; padding-right: 5px;" class="fa fa-arrow-left"></i>Previous
                 </a>
@@ -31,9 +32,55 @@
                 </a>
                 <!-- EDITOR -->
                 <div id="registrationEditor"></div>
-                <p>Last saved: <span data-bind="text: $root.lastSaved()"></span></p>
-                <button data-bind="css: {disabled: disableSave},                                 
-                                   click: save" type="button" class="btn btn-success">Save</button>
+                <p>Last saved: <span data-bind="text: $root.lastSaved()"></span>
+                </p>
+                <button data-bind="disable: disableSave, 
+                                   click: save" type="button" class="btn btn-success">Save
+                </button>
+                <hr />
+                <div class="well">
+                  <h4> Comments </h4>
+                  <ul class="list-group" data-bind="foreach: {data: comments, as: 'comment'}">                    <li class="list-group-item">
+                      <div class="row">
+                        <div class="col-md-12">
+                          <div class="row">
+                            <div class="col-sm-9">
+                            <span data-bind="text: comment.author"></span> said ...
+                            </div>
+                            <div class="col-sm-3">
+                            <div style="text-align: right;" class="btn-group">
+                              <button data-bind="disable: comment.saved,
+                                            click: comment.saved.bind(null, true)" 
+                                      class="btn btn-success fa fa-save registration-editor-comment-save"></button>
+                              <button data-bind="enable: comment.canEdit,
+                                                 click: comment.saved.bind(null, false)"
+                                      class="btn btn-info fa fa-pencil"></button>
+                              <button data-bind="enable: comment.canDelete,
+                                                 click: $root.comments.remove"
+                                      class="btn btn-danger fa fa-times"></button>
+                            </div>                               
+                            </div>
+                          </div>
+                          <br />
+                          <div class="row">
+                            <div class="col-md-12 form-group">
+                              <textarea class="form-control"
+                                        data-bind="disable: comment.saved,
+                                                   value: comment.value" 
+                                        type="text" placeholder="The author removed this comment"></textarea>
+                            </div>
+                          </div>
+                        </div>
+                    </li>
+                  </ul>
+                  <div class="input-group">                    
+                    <input class="form-control registration-editor-comment" type="text" data-bind="value: $root.nextComment, valueUpdate: 'keyup'" />
+                    <span class="input-group-btn" >
+                      <button class="btn btn primary" data-bind="click: addComment,
+                                                                 enable: $root.allowAddNext">Add</button>
+                    </span>
+                  </div>
+                </div>                               
             </div>
         </div>
     </div>

--- a/website/templates/project/registration_editor.mako
+++ b/website/templates/project/registration_editor.mako
@@ -8,16 +8,18 @@
                             <i class="fa fa-caret-right"></i>
                         </a>
                         <span class="btn-group-vertical" role="group">
-                  <ul class="list-group" data-bind="foreach: questions">
-                    <li data-bind="css: {
-                                     list-group-item-success: $root.isComplete($data), 
-                                     list-group-item-warning: !$root.isComplete($data),
-                                     registration-editor-question-current: $root.isCurrent($parentContext.$index(), $index())
-                                   },
-                                   click: $root.selectQuestion.bind($root, page),
-                                   text: nav"
-                        class="registration-editor-question list-group-item">
+                  <ul class="list-group" data-bind="foreach: {data: Object.keys(page.questions), as: 'qid'}">
+                    <span data-bind="with: page.questions[qid]">
+                      <li data-bind="css: {
+                                       list-group-item-success: isComplete,
+                                       list-group-item-warning: !isComplete(),
+                                       registration-editor-question-current: $root.currentQuestion().id === $data.id
+                                     },
+                                     click: $root.currentQuestion.bind($root, $data),
+                                     text: nav"
+                          class="registration-editor-question list-group-item">
                     </li>
+                    </span>
                   </ul>
                 </span>
                     </li>
@@ -31,57 +33,18 @@
                     <i style="display:inline-block; padding-right: 5px; padding-left: 5px;" class="fa fa-arrow-right"></i>
                 </a>
                 <!-- EDITOR -->
-                <div id="registrationEditor"></div>
+                <div data-bind="if: currentQuestion">
+                  <div id="registrationEditor" data-bind="template: {data: currentQuestion, name: 'editor'}">
+                  </div>
+                </div>
                 <p>Last saved: <span data-bind="text: $root.lastSaved()"></span>
                 </p>
-                <button data-bind="disable: disableSave, 
-                                   click: save" type="button" class="btn btn-success">Save
+                <button data-bind="click: save" type="button" class="btn btn-success">Save
                 </button>
-                <hr />
-                <div class="well">
-                  <h4> Comments </h4>
-                  <ul class="list-group" data-bind="foreach: {data: comments, as: 'comment'}">                    <li class="list-group-item">
-                      <div class="row">
-                        <div class="col-md-12">
-                          <div class="row">
-                            <div class="col-sm-9">
-                            <span data-bind="text: comment.author"></span> said ...
-                            </div>
-                            <div class="col-sm-3">
-                            <div style="text-align: right;" class="btn-group">
-                              <button data-bind="disable: comment.saved,
-                                            click: comment.saved.bind(null, true)" 
-                                      class="btn btn-success fa fa-save registration-editor-comment-save"></button>
-                              <button data-bind="enable: comment.canEdit,
-                                                 click: comment.saved.bind(null, false)"
-                                      class="btn btn-info fa fa-pencil"></button>
-                              <button data-bind="enable: comment.canDelete,
-                                                 click: $root.comments.remove"
-                                      class="btn btn-danger fa fa-times"></button>
-                            </div>                               
-                            </div>
-                          </div>
-                          <br />
-                          <div class="row">
-                            <div class="col-md-12 form-group">
-                              <textarea class="form-control"
-                                        data-bind="disable: comment.saved,
-                                                   value: comment.value" 
-                                        type="text" placeholder="The author removed this comment"></textarea>
-                            </div>
-                          </div>
-                        </div>
-                    </li>
-                  </ul>
-                  <div class="input-group">                    
-                    <input class="form-control registration-editor-comment" type="text" data-bind="value: $root.nextComment, valueUpdate: 'keyup'" />
-                    <span class="input-group-btn" >
-                      <button class="btn btn primary" data-bind="click: addComment,
-                                                                 enable: $root.allowAddNext">Add</button>
-                    </span>
-                  </div>
                 </div>                               
             </div>
         </div>
     </div>
 </div>
+
+<%include file="registration_editor_templates.mako" />

--- a/website/templates/project/registration_editor_extensions.mako
+++ b/website/templates/project/registration_editor_extensions.mako
@@ -1,0 +1,4 @@
+<!-- OSF Upload -->
+<script type="text/html" id="osf-upload">
+  <div data-bind="attr.id: $data.id, osfUploader"></div>
+</script>

--- a/website/templates/project/registration_editor_templates.mako
+++ b/website/templates/project/registration_editor_templates.mako
@@ -1,0 +1,127 @@
+<!-- String Types -->
+<script type="text/html" id="string">  
+  <span data-bind="template: {data: $data, name: format}"></span>
+</script>
+
+<script type="text/html" id="text">  
+  <input data-bind="valueUpdate: 'keyup', value: value" type="text" class="form-control">          
+</script>
+<script type="text/html" id="textarea">  
+  <textarea data-bind="html: value" class="form-control"> </textarea>         
+</script>
+<!-- Number Types -->
+<script type="text/html" id="number">  
+  <input data-bind="value: value" type="text" class="form-control">          
+</script>
+<!-- Enum Types -->
+<script type="text/html" id="choose">
+  <span data-bind="template: {data: $data, name: format}"></span>
+</script>
+
+<script type="text/html" id="list">
+  <div data-bind="foreach: {data: options, as: 'option'}">
+    <div class="row">
+    <div class="col-sm-9">
+      <blockquote>
+        <p style="font-size: 75%;" data-bind="text: $data"></p>
+      </blockquote>
+    </div>
+    <div class="col-sm-3">
+      <span style="font-size: 200%;" 
+         class="btn fa" 
+         data-bind="css: {
+                      fa-check-circle-o: $parent.value() === $index,
+                      fa-circle-o: $parent.value() !== $index
+                    },
+                    click: $parent.setValue.bind(null, $index)"></span>
+    </div>
+    </div>
+  </div>
+</script>
+
+<script type="text/html" id="object">  
+  <span data-bind="foreach: {data: $root.iterObject($data.properties)}">
+      <div data-bind="template: {data: value, name: value.type}"></div>
+      <hr />
+    </span>
+  </span>
+</script>
+
+<!-- Base Template -->
+<script type="text/html" id="editorBase">
+  <div class="well" style="padding-bottom: 0px;">
+    <div class="row">
+      <div class="col-md-12">
+        <div class="form-group">
+          <label class="control-label" data-bind="text: title"></label>
+          <p class="help-block" data-bind="text: description"></p>
+          <span class="example-block">
+            <a data-bind="click: toggleExample">Show Example</a>            
+            <p data-bind="visible: showExample, text: help"></p>
+          </span>         
+          <br />
+          <br />
+          <div class="row">
+            <div class="col-md-12">
+              <div class="form-group" data-bind="css: {has-succes: $data.isComplete}">
+                <span data-bind="with: $root.context($data)">
+                  <div data-bind="disable: $root.readonly, template: {data: $data, name: type}"></div>
+                </span>
+              </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</script>
+<script type="text/html" id="editor">
+  <span data-bind="template: {data: $data, name: 'editorBase'}"></span>
+  <div class="row">
+    <div class="col-md-12">
+      <div class="well" data-bind="template: {data: $data, name: 'commentable'}"></div>
+    </div>
+  </div>
+</script>
+
+<!-- Commnetable -->
+<script type="text/html" id="commentable">
+    <h4> Comments </h4>
+    <ul class="list-group" data-bind="foreach: {data: comments, as: 'comment'}">
+        <li class="list-group-item">
+            <div class="row">
+                <div class="col-md-12">
+                    <div class="row">
+                        <div class="col-sm-9">
+                            <span data-bind="text: comment.author"></span> said ...
+                        </div>
+                        <div class="col-sm-3">
+                            <div style="text-align: right;" class="btn-group">
+                                <button data-bind="disable: comment.saved,
+                                   click: comment.saved.bind(null, true)" class="btn btn-success fa fa-save registration-editor-comment-save"></button>
+                                <button data-bind="enable: comment.canEdit,
+                                   click: comment.saved.bind(null, false)" class="btn btn-info fa fa-pencil"></button>
+                                <button data-bind="enable: comment.canDelete,
+                                   click: $root.comments.remove" class="btn btn-danger fa fa-times"></button>
+                            </div>
+                        </div>
+                    </div>
+                    <br />
+                    <div class="row">
+                        <div class="col-md-12 form-group">
+                            <textarea class="form-control" data-bind="disable: comment.saved,
+                                                        value: comment.value" type="text" placeholder="The author removed this comment"></textarea>
+                        </div>
+                    </div>
+                </div>
+        </li>
+    </ul>
+    <div class="input-group">
+      <input class="form-control registration-editor-comment" type="text" data-bind="value: nextComment, valueUpdate: 'keyup'" />
+      <span class="input-group-btn">
+        <button class="btn btn primary" data-bind="click: $data.addComment,
+                                                   enable: $data.allowAddNext">Add</button>
+      </span>
+    </div>
+</script>
+
+<%include file="registration_editor_extensions.mako" />

--- a/website/templates/project/registrations.mako
+++ b/website/templates/project/registrations.mako
@@ -65,8 +65,8 @@
           <h4 class="list-group-item-heading">          
             <div class="progress progress-bar-md">
               <div class="progress-bar" role="progressbar" aria-valuemin="0" aria-valuemax="100"
-               data-bind="attr.aria-completion: completion,
-                          style: {width: completion + '%'}">
+                   data-bind="attr.aria-completion: completion,
+                              style: {width: completion + '%'}">
                 <span class="sr-only"></span>
               </div>
             </div>
@@ -76,9 +76,9 @@
             <p>last updated about <span data-bind="text: $root.formattedDate(updated)"></span></p>
             <p>
               <button class="btn btn-success"
-                      data-bind="click: $root.editDraft"><i class="fa fa-pencil"></i>Edit</button>
+                      data-bind="click: $root.editDraft"><i style="margin-right: 5px;" class="fa fa-pencil"></i>Edit</button>
               <button class="btn btn-danger"
-                      data-bind="click: $root.deleteDraft"><i class="fa fa-times"></i>Delete</button>
+                      data-bind="click: $root.deleteDraft"><i style="margin-right: 5px;" class="fa fa-times"></i>Delete</button>
             </p>
           </h4>
         </li>

--- a/website/templates/project/registrations.mako
+++ b/website/templates/project/registrations.mako
@@ -138,7 +138,7 @@ ${parent.javascript_bottom()}
                   </span>
                 </div>
                 <div class="col-md-1">
-                  <button data-bind="click: $root.launchEditor.bind($root, null, $data)" class="btn btn-primary">Use</button>
+                  <button data-bind="click: $root.launchEditor.bind($root, $root.blankDraft($data))" class="btn btn-primary">Use</button>
                 </div>
               </div>
             </h3>


### PR DESCRIPTION
New DraftRegistration fields
- `is_pending_review` - default to False
  - Set in `send_for_review`
- `schema_name`
  - Set in `create_draft_registration`
  - Used to query for necessary nodes in Admin panel

View changes
- `send_for_review` - POST endpoint at `/project/<pid>/draft/needs_review`
  - Sets `is_pending_review` = True
  - Sends email to all users in hardcoded `ADMIN_USERNAMES` list
  - Not sure of best URL, `/drafts/send_for_review` may be better too. Up to you
- `get_all_drafts`
  - Changed to only return pending review drafts and prereg drafts

Small bug fix in Sam's `simple.json`

More details in commits
