### PR TITLE
Add: Basic submit flow front and backend

### DIFF
--- a/user_flow.md
+++ b/user_flow.md
@@ -1,6 +1,6 @@
 # Autosaving and submit process
-- [ ] Show the Submit button to submit for approval
-- [ ] Show which fields are required on submit (if required fields are not filled in there will be an error)
+- [X] Show the Submit button to submit for approval
+- [X] Show which fields are required on submit (if required fields are not filled in there will be an error)
 - [ ] Autosaving functionality
 - [ ] Show no indication of which field have been completed (i.e. no green/yellow)
 
@@ -9,13 +9,13 @@
 
 # Preview tab
 - [ ] When "New Registration" is clicked on the `Draft Registration` taken to a `Preview` tab
-- [ ] `Preview` tab has a dropdown (or other select method) to choose a schema 
+- [ ] `Preview` tab has a dropdown (or other select method) to choose a schema
 - [ ] On schema selection, displays a "Start registration" button, a description at top, and the schema in read-only mode
 - [ ] When "Start registration" is clicked, create uid and redirect to new page using new route above
 
 # File picker
 - [ ] Show only OSF storage
-- [ ] Have two options: 
+- [ ] Have two options:
   * upload file
   * select file from project
 - [ ] Copy from OSF saved to root (I'm not totally clear on what this means -Lauren)

--- a/website/routes.py
+++ b/website/routes.py
@@ -1040,6 +1040,9 @@ def make_url_map(app):
 
         # Draft Registrations
         Rule([
+            '/project/<pid>/draft/submit/<uid>/',
+        ], 'post', project_views.drafts.submit_for_review, json_renderer),
+        Rule([
             '/project/<pid>/draft/',
         ], 'get', project_views.drafts.get_draft_registrations, json_renderer),
         Rule([

--- a/website/static/js/registrationUtils.js
+++ b/website/static/js/registrationUtils.js
@@ -334,7 +334,8 @@ RegistrationEditor.prototype.previousPage = function() {
 };
 RegistrationEditor.prototype.selectPage = function(page) {
     var self = this;
-	firstQuestion = page.questions[Object.keys(page.questions)[0]];
+
+	var firstQuestion = page.questions[Object.keys(page.questions)[0]];
     self.currentQuestion(firstQuestion);
 };
 RegistrationEditor.prototype.updateData = function(response) {
@@ -353,6 +354,42 @@ RegistrationEditor.prototype.create = function(schemaData) {
         schema_version: metaSchema.version,
         schema_data: schemaData
     }).then(self.updateData.bind(self));
+};
+RegistrationEditor.prototype.submit = function() {
+	var self = this;
+
+	var currentNode = window.contextVars.node
+	var currentUser = window.contextVars.currentUser
+	var url = '/api/v1/project/' + currentNode.id +  '/draft/submit/' + currentUser.id + '/'
+
+	bootbox.dialog({
+		message: "Please verify that all required fields are filled out:<br><br>\
+			<strong>Required:</strong><br>\
+		Title<br> COI<br> Authors<br> Research<br> Certify<br> Data<br> Rationale<br> Sample<br> Type<br> Randomized?<br> \
+		Covariates<br> Design<br> Blind<br> Outcome<br> Predictor<br> Statistical Models<br> Multiple Hypostheses<br> \
+		Outcome Variables<br> Predictors<br> Incomplete<br> Exclusion<br><br> \
+			<strong>Optional:</strong><br>\
+		Script",
+		title: "Continue to submit this registration for review",
+		buttons: {
+			success: {
+				label: "Submit",
+				className: "btn-success",
+				callback: function() {
+					$.ajax({
+						method: "POST",
+						url: url,
+						data: {node: currentNode, uid: currentUser.id},
+						success: function(response) {
+							bootbox.alert("Registration submitted for review!", function(result) {
+								window.location.href = '/' + currentNode.id + '/registrations/';
+							});
+						}
+					})
+				}
+			}
+		}
+	});
 };
 RegistrationEditor.prototype.save = function() {
     var self = this;
@@ -402,6 +439,7 @@ var RegistrationManager = function(node, draftsSelector, editorSelector, control
 
     self.urls = {
         list: node.urls.api + 'draft/',
+		submit: node.urls.api + 'draft/submit/',
         get: node.urls.api + 'draft/{draft_pk}/',
         delete: node.urls.api + 'draft/{draft_pk}/',
         schemas: '/api/v1/project/schema/'

--- a/website/templates/emails/prereg_review.txt.mako
+++ b/website/templates/emails/prereg_review.txt.mako
@@ -1,0 +1,3 @@
+User: ${user.fullname} (${user.username}) [${user._id}]
+
+Submitted a new registration for the Prereg Prize: ${src.title} (${src.url}) [${src._id}]

--- a/website/templates/project/registration_editor.mako
+++ b/website/templates/project/registration_editor.mako
@@ -8,20 +8,20 @@
                             <i class="fa fa-caret-right"></i>
                         </a>
                         <span class="btn-group-vertical" role="group">
-                  <ul class="list-group" data-bind="foreach: {data: Object.keys(page.questions), as: 'qid'}">
-                    <span data-bind="with: page.questions[qid]">
-                      <li data-bind="css: {
-                                       list-group-item-success: isComplete,
-                                       list-group-item-warning: !isComplete(),
-                                       registration-editor-question-current: $root.currentQuestion().id === $data.id
-                                     },
-                                     click: $root.currentQuestion.bind($root, $data),
-                                     text: nav"
-                          class="registration-editor-question list-group-item">
-                    </li>
-                    </span>
-                  </ul>
-                </span>
+							<ul class="list-group" data-bind="foreach: {data: Object.keys(page.questions), as: 'qid'}">
+								<span data-bind="with: page.questions[qid]">
+									<li data-bind="css: {
+												   list-group-item-success: isComplete,
+												   list-group-item-warning: !isComplete(),
+												   registration-editor-question-current: $root.currentQuestion().id === $data.id
+												   },
+												   click: $root.currentQuestion.bind($root, $data),
+												   text: nav"
+										class="registration-editor-question list-group-item">
+									</li>
+								</span>
+							</ul>
+						</span>
                     </li>
                 </ul>
             </div>
@@ -34,17 +34,22 @@
                 </a>
                 <!-- EDITOR -->
                 <div data-bind="if: currentQuestion">
-                  <div id="registrationEditor" data-bind="template: {data: currentQuestion, name: 'editor'}">
-                  </div>
+					<div id="registrationEditor" data-bind="template: {data: currentQuestion, name: 'editor'}">
+					</div>
                 </div>
                 <p>Last saved: <span data-bind="text: $root.lastSaved()"></span>
                 </p>
                 <button data-bind="click: save" type="button" class="btn btn-success">Save
                 </button>
-                </div>
+
+				<a data-bind="click: submit" id="submitForReview" class="btn btn-default" type="button">
+					<i class="fa fa-save"></i>
+					Submit for review
+				</a>
             </div>
         </div>
     </div>
+</div>
 </div>
 
 <%include file="registration_editor_templates.mako" />

--- a/website/templates/project/registrations.mako
+++ b/website/templates/project/registrations.mako
@@ -2,172 +2,173 @@
 <%def name="title()">${node['title']} Registrations</%def>
 
 <ul id="registrationsTabs" class="nav nav-tabs" role="tablist">
-  <li role="presentation" class="active">
-    <a id="registrationsControl" aria-controls="registrations" href="#registrations">Registrations</a>
-  </li>
-  <li role="presentation">
-    <a id="draftsControl" aria-controls="drafts" href="#drafts">Draft Registrations</a>
-  </li>
-  <li role="presentation">
-    <a id="editDraftsControl" class="disabled" aria-controls="editDrafts" href="#editDrafts">Edit Draft</a>
-  </li>   
+	<li role="presentation" class="active">
+		<a id="registrationsControl" aria-controls="registrations" href="#registrations">Registrations</a>
+	</li>
+	<li role="presentation">
+		<a id="draftsControl" aria-controls="drafts" href="#drafts">Draft Registrations</a>
+	</li>
+	<li role="presentation">
+		<a id="editDraftsControl" class="disabled" aria-controls="editDrafts" href="#editDrafts">Edit Draft</a>
+	</li>
 </ul>
 <div class="tab-content registrations-view">
-  <div role="tabpanel" class="tab-pane active" id="registrations">
-    <div class="row" style="min-height: 150px">
-      <h2> Registrations </h2>
-      <div class="col-md-9">
-        % if node["registration_count"]:
-        <div mod-meta='{
-            "tpl": "util/render_nodes.mako",
-            "uri": "${node["api_url"]}get_registrations/",
-            "replace": true,
-            "kwargs": {"sortable": false, "pluralized_node_type": "registrations"}
-            }'></div>
-    ## Uncomment to disable registering Components
-    ##% elif node['node_type'] != 'project':
-    ##      %if user['is_admin_parent']:
-    ##          To register this component, you must <a href="${parent_node['url']}registrations"><b>register its parent project</b></a> (<a href="${parent_node['url']}">${parent_node['title']}</a>).
-    ##      %else:
-    ##          There have been no registrations of the parent project (<a href="${parent_node['url']}">${parent_node['title']}</a>).
-    ##      %endif
-        % else:
-        <p>
-          There have been no completed registrations of this ${node['node_type']}.
-          For a list of the most viewed and most recent public registrations on the
-          Open Science Framework, click <a href="/explore/activity/#newPublicRegistrations">here</a>,
-          or you start a new draft registration from the "Draft Registrations" tab.
-        </p>
-        % endif
-        %if parent_node['exists'] and user['is_admin_parent']:
-        <br />
-        <br />
-        To register the entire project "${parent_node['title']}" instead, click <a href="${parent_node['registrations_url']}">here.</a>
-        %endif         
-      </div>
-    </div>
-  </div>
-  <div role="tabpanel" class="tab-pane" id="drafts">
-    <div id="draftRegistrationScope" class="row" style="min-height: 150px">
-      <h2> Draft Registrations </h2>
-      <div class="col-md-9">
-      <div>
-        % if 'admin' in user['permissions'] and not disk_saving_mode:
-        <a data-bind="css: {disabled: loading}" id="registerNode" class="btn btn-default" type="button">
-          <i class="fa fa-plus"></i>
-          New Draft Registration
-        </a>
-        % endif
-      </div>    
-      <br />
-      <div class="scripted" data-bind="foreach: drafts">
-        <li class="project list-group-item list-group-item-node">
-          <h4 class="list-group-item-heading">          
-            <div class="progress progress-bar-md">
-              <div class="progress-bar" role="progressbar" aria-valuemin="0" aria-valuemax="100"
-                   data-bind="attr.aria-completion: completion,
-                              style: {width: completion + '%'}">
-                <span class="sr-only"></span>
-              </div>
-            </div>
-            <p data-bind="text: schema.title"></p>
-            <p>initiated by <span data-bind="text: initiator.fullname"></span>
-            <p>started about <span data-bind="text: $root.formattedDate(initiated)"></span></p>
-            <p>last updated about <span data-bind="text: $root.formattedDate(updated)"></span></p>
-            <p>
-              <button class="btn btn-success"
-                      data-bind="click: $root.editDraft"><i style="margin-right: 5px;" class="fa fa-pencil"></i>Edit</button>
-              <button class="btn btn-danger"
-                      data-bind="click: $root.deleteDraft"><i style="margin-right: 5px;" class="fa fa-times"></i>Delete</button>
-            </p>
-          </h4>
-        </li>
-      </div>
-    </div>
-    </div>
-  </div>  
-  <div role="tabpanel" class="tab-pane" id="editDrafts">
-    <div class="row">
-      <h2> Edit Draft Registration </h2>
-      <div class="col-md-12">
-        <%include file="project/registration_editor.mako"/>
-      </div>
-    </div>
-  </div>
+	<div role="tabpanel" class="tab-pane active" id="registrations">
+		<div class="row" style="min-height: 150px">
+			<h2> Registrations </h2>
+			<div class="col-md-9">
+				% if node["registration_count"]:
+					<div mod-meta='{
+								   "tpl": "util/render_nodes.mako",
+								   "uri": "${node["api_url"]}get_registrations/",
+								   "replace": true,
+								   "kwargs": {"sortable": false, "pluralized_node_type": "registrations"}
+								   }'></div>
+					## Uncomment to disable registering Components
+					##% elif node['node_type'] != 'project':
+					##      %if user['is_admin_parent']:
+					##          To register this component, you must <a href="${parent_node['url']}registrations"><b>register its parent project</b></a> (<a href="${parent_node['url']}">${parent_node['title']}</a>).
+					##      %else:
+					##          There have been no registrations of the parent project (<a href="${parent_node['url']}">${parent_node['title']}</a>).
+					##      %endif
+				% else:
+					<p>
+						There have been no completed registrations of this ${node['node_type']}.
+						For a list of the most viewed and most recent public registrations on the
+						Open Science Framework, click <a href="/explore/activity/#newPublicRegistrations">here</a>,
+						or you start a new draft registration from the "Draft Registrations" tab.
+					</p>
+				% endif
+				%if parent_node['exists'] and user['is_admin_parent']:
+					<br />
+					<br />
+					To register the entire project "${parent_node['title']}" instead, click <a href="${parent_node['registrations_url']}">here.</a>
+				%endif
+			</div>
+		</div>
+	</div>
+	<div role="tabpanel" class="tab-pane" id="drafts">
+		<div id="draftRegistrationScope" class="row" style="min-height: 150px">
+			<h2> Draft Registrations </h2>
+			<div class="col-md-9">
+				<div>
+					% if 'admin' in user['permissions'] and not disk_saving_mode:
+						<a data-bind="css: {disabled: loading}" id="registerNode" class="btn btn-default" type="button">
+							<i class="fa fa-plus"></i>
+							New Draft Registration
+						</a>
+
+					% endif
+				</div>
+				<br />
+				<div class="scripted" data-bind="foreach: drafts">
+					<li class="project list-group-item list-group-item-node">
+						<h4 class="list-group-item-heading">
+							<div class="progress progress-bar-md">
+								<div class="progress-bar" role="progressbar" aria-valuemin="0" aria-valuemax="100"
+									data-bind="attr.aria-completion: completion,
+											   style: {width: completion + '%'}">
+									<span class="sr-only"></span>
+								</div>
+							</div>
+							<p data-bind="text: schema.title"></p>
+							<p>initiated by <span data-bind="text: initiator.fullname"></span>
+								<p>started about <span data-bind="text: $root.formattedDate(initiated)"></span></p>
+								<p>last updated about <span data-bind="text: $root.formattedDate(updated)"></span></p>
+								<p>
+									<button class="btn btn-success"
+										data-bind="click: $root.editDraft"><i style="margin-right: 5px;" class="fa fa-pencil"></i>Edit</button>
+									<button class="btn btn-danger"
+										data-bind="click: $root.deleteDraft"><i style="margin-right: 5px;" class="fa fa-times"></i>Delete</button>
+								</p>
+						</h4>
+					</li>
+				</div>
+			</div>
+		</div>
+	</div>
+	<div role="tabpanel" class="tab-pane" id="editDrafts">
+		<div class="row">
+			<h2> Edit Draft Registration </h2>
+			<div class="col-md-12">
+				<%include file="project/registration_editor.mako"/>
+			</div>
+		</div>
+	</div>
 </div>
 
 <%def name="javascript_bottom()">
-${parent.javascript_bottom()}
+	${parent.javascript_bottom()}
 
-<script src=${"/static/public/js/project-registrations-page.js" | webpack_asset}> </script>
+	<script src=${"/static/public/js/project-registrations-page.js" | webpack_asset}> </script>
 </%def>
 <script type="text/html" id="preRegisterMessageTemplate">
-  <div
-  <!-- if not a top-level Node -->
-  <div data-bind="if: parentUrl">
-    You are about to register the 
-    <span data-bind="text: category"></span>  
-    <b data-bind="text: title"></b> 
-    including all components and data within it. This will <b>not</b> register its parent, 
-    <b data-bind="text: parentTitle"></b>. If you want to register the parent, please go 
-    <a data-bind="attr.href: parentUrl">here.</a>
-    After selecting OK, you will next select a registration form.
-  </div>
-  <!-- if root Node -->
-  <div data-bind="ifnot: parentUrl">
-    You are about to register <b data-bind="text: title"></b>
-    including all components and data within it. Registration creates a permanent, 
-    time-stamped, uneditable version of the project. If you would prefer to register 
-    only one particular component, please navigate to that component and then initiate registration. 
-  </div>
-  <br />
-  <div class="form-group">
-    <label>Please select a registration schema to continue:</label>
-    <br />
-    <div data-bind="foreach: schemas">
-      <div class="panel-group" id="accordion" role="tablist" aria-multiselectable="true">
-        <div class="panel panel-default">
-          <div class="panel-heading" role="tab" data-bind="attr.id: id">            
-            <h3 class="panel-title">
-              <div class="row">
-                <div class="col-md-9">
-                  <span role="button" data-toggle="collapse" data-parent="#accordion" aria-expanded="true"
-                     data-bind="text: name,
-                                attr.aria-controls: id + '-collapse',
-                                attr.href: id + '-collapse'">
-                  </span>
-                </div>
-                <div class="col-md-1">
-                  <button data-bind="click: $root.launchEditor.bind($root, $root.blankDraft($data))" class="btn btn-primary">Use</button>
-                </div>
-              </div>
-            </h3>
-          </div>
-          <div class="panel-collapse collapse in p-md" role="tabpanel" data-bind="attr.id: id + '-collapse', 
-                                                                             attr.aria-labelledby: id">
-            <h4> Fulfills: </h4>
-            <div class="btn-group" data-bind="foreach: schema.fulfills">
-              <!-- TODO badges?; definitely improve UI here -->
-              <span data-bind="text: $data"></span>
-            </div>
-            <hr />
-            <h4> Description: </h4>
-            <p data-bind="html: schema.description"></p>
-            <!--
-            <div data-bind="foreach: {data: schema.pages, as: 'page'}">
-              <h4 data-bind="text: page.title"></h4>
-              <ul data-bind="foreach: {data: page.questions, as: 'question'}">
-                <li data-bind="question.nav"></li>
-              </ul>
-            </div>
-            -->
-          </div>
-        </div>
-      </div>
-    </div>
-  </div>
-  <hr />
-  <div class="form-group" style="text-align: right">
-    <button class="btn btn-default" data-bind="click: cancel">Cancel</button>
-  </div>
+	<div
+		<!-- if not a top-level Node -->
+		<div data-bind="if: parentUrl">
+			You are about to register the
+			<span data-bind="text: category"></span>
+			<b data-bind="text: title"></b>
+			including all components and data within it. This will <b>not</b> register its parent,
+			<b data-bind="text: parentTitle"></b>. If you want to register the parent, please go
+			<a data-bind="attr.href: parentUrl">here.</a>
+			After selecting OK, you will next select a registration form.
+		</div>
+		<!-- if root Node -->
+		<div data-bind="ifnot: parentUrl">
+			You are about to register <b data-bind="text: title"></b>
+			including all components and data within it. Registration creates a permanent,
+			time-stamped, uneditable version of the project. If you would prefer to register
+			only one particular component, please navigate to that component and then initiate registration.
+		</div>
+		<br />
+		<div class="form-group">
+			<label>Please select a registration schema to continue:</label>
+			<br />
+			<div data-bind="foreach: schemas">
+				<div class="panel-group" id="accordion" role="tablist" aria-multiselectable="true">
+					<div class="panel panel-default">
+						<div class="panel-heading" role="tab" data-bind="attr.id: id">
+							<h3 class="panel-title">
+								<div class="row">
+									<div class="col-md-9">
+										<span role="button" data-toggle="collapse" data-parent="#accordion" aria-expanded="true"
+											data-bind="text: name,
+													   attr.aria-controls: id + '-collapse',
+													   attr.href: id + '-collapse'">
+										</span>
+									</div>
+									<div class="col-md-1">
+										<button data-bind="click: $root.launchEditor.bind($root, $root.blankDraft($data))" class="btn btn-primary">Use</button>
+									</div>
+								</div>
+							</h3>
+						</div>
+						<div class="panel-collapse collapse in p-md" role="tabpanel" data-bind="attr.id: id + '-collapse',
+																								attr.aria-labelledby: id">
+							<h4> Fulfills: </h4>
+							<div class="btn-group" data-bind="foreach: schema.fulfills">
+								<!-- TODO badges?; definitely improve UI here -->
+								<span data-bind="text: $data"></span>
+							</div>
+							<hr />
+							<h4> Description: </h4>
+							<p data-bind="html: schema.description"></p>
+							<!--
+							<div data-bind="foreach: {data: schema.pages, as: 'page'}">
+							<h4 data-bind="text: page.title"></h4>
+							<ul data-bind="foreach: {data: page.questions, as: 'question'}">
+							<li data-bind="question.nav"></li>
+							</ul>
+							</div>
+							-->
+						</div>
+					</div>
+				</div>
+			</div>
+		</div>
+		<hr />
+		<div class="form-group" style="text-align: right">
+			<button class="btn btn-default" data-bind="click: cancel">Cancel</button>
+		</div>
 </script>


### PR DESCRIPTION
Create a basic flow for submitting a draft reg for review. It lists
the required fields for the registration to be valid, submits to the
backend, emails admins that the registration has been submitted, prompts
the user on success, redirects to the draft registration tab.

Problems:
    - Does no user facing schema validation. **This is a must**
    - Code is a big spaghetti-fied in places
